### PR TITLE
MeterValue corrections

### DIFF
--- a/src/entity/ChargingStation.js
+++ b/src/entity/ChargingStation.js
@@ -924,10 +924,21 @@ class ChargingStation extends AbstractTenantEntity {
       if (this.getOcppVersion() === Constants.OCPP_VERSION_16) { //value.sampledValue 
         if (Array.isArray(value.sampledValue)) {
           for (const sampledValue of value.sampledValue) {
+            // clone header
+            // eslint-disable-next-line prefer-const
+            let newLocalMeterValue = JSON.parse(JSON.stringify(newMeterValue));
             // Normalize
             value.value = sampledValue.value;
-            newMeterValue.value = parseInt(value.value);
-            newMeterValues.values.push(newMeterValue);
+            newLocalMeterValue.attribute = {};
+            // enrich with OCPP16 attributes
+            newLocalMeterValue.attribute.context = ( sampledValue.context ? sampledValue.context : Constants.METER_VALUE_CTX_SAMPLE_PERIODIC);
+            newLocalMeterValue.attribute.format = ( sampledValue.format ? sampledValue.format : Constants.METER_VALUE_FORMAT_RAW);
+            newLocalMeterValue.attribute.measurand = ( sampledValue.measurand ? sampledValue.measurand : Constants.METER_VALUE_MEASURAND_IMPREG);
+            newLocalMeterValue.attribute.location = ( sampledValue.location ? sampledValue.location : Constants.METER_VALUE_LOCATION_OUTLET);
+            newLocalMeterValue.attribute.unit = ( sampledValue.unit ? sampledValue.unit : Constants.METER_VALUE_UNIT_WH);
+            newLocalMeterValue.attribute.phase = ( sampledValue.phase ? sampledValue.phase : '');
+            newLocalMeterValue.value = parseInt(value.value);
+            newMeterValues.values.push(newLocalMeterValue);
           }
         } else {
           // Normalize

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -101,6 +101,11 @@ module.exports = {
 
   METER_VALUE_CTX_SAMPLE_PERIODIC: 'Sample.Periodic',
   METER_VALUE_CTX_SAMPLE_CLOCK: 'Sample.Clock',
+  METER_VALUE_FORMAT_RAW: 'Raw',
+  METER_VALUE_MEASURAND_IMPREG: 'Energy.Active.Import.Register',
+  METER_VALUE_LOCATION_OUTLET: 'Outlet',
+  METER_VALUE_UNIT_WH: 'Wh',
+  
 
   WS_UNSUPPORTED_DATA: 1007,
 


### PR DESCRIPTION
When processing a table of meter value all entries in newMeterValues were identical because they was reusing teh same instance.
So the hash key was identical and it explain the exception in MongoDB.
So now I clone the meterValue into a new instance and enrich it with meterValue paramter.

tested with my simulator. I am currently not able to run Unit test on my config :(