### PR TITLE
Fix a start failure on Windows.

### DIFF
--- a/cloud-infos.md
+++ b/cloud-infos.md
@@ -23,7 +23,7 @@
 
 ## Common
 
-### NIGINX
+### NGINX
 #### Logs
 - /var/log/nginx/access.log
 - /var/log/nginx/error.log

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"mustache": "^2.3.0",
 		"node-authorization": "^1.0.5",
 		"node-cron": "^1.2.1",
-		"node-pre-gyp": "^0.10.3",
+		"node-pre-gyp": "^0.12.0",
 		"nodemailer": "^4.7.0",
 		"nodemailer-smtp-transport": "^2.7.4",
 		"passport": "^0.4.0",
@@ -49,6 +49,7 @@
 		"passport-strategy": "^1.0.0",
 		"password-generator": "^2.1.0",
 		"promise": "^8.0.1",
+		"simple-odata-server": "^1.1.1",
 		"soap": "^0.24.0",
 		"socket.io": "^2.0.3",
 		"source-map-support": "^0.5.6",
@@ -56,8 +57,7 @@
 		"urlencode": "^1.1.0",
 		"uuid": "^3.3.2",
 		"winston": "^3.0.0",
-		"xml-formatter": "^1.0.1",
-		"simple-odata-server": "^1.1.1"
+		"xml-formatter": "^1.0.1"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.1.7",

--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ In the following, you will need to run Powershell as an administrator.
     ```
   
   Change the path to *mongod* and *mongod.cfg* accordingly if needed.  
-  Open the **Services** application, search for MongoDB, open service properties and Log on as **Network Service** user with empty password.
+  Open the **Services** application, search for the MongoDB service, open the service properties and Log on as **Network Service** user with empty password.
 
 * Start the MongoDB service:
     ```


### PR DESCRIPTION
Bump the node-pre-gyp version to latest to avoid a start failure on
Windows. During the build of one of its dependency node-gyp, you now have a
build failure against OpenSSL that seems harmless (C header location)
but now the server just starts without error.

Fix a typo and reorder the package list while at it.

Signed-off-by: Jerome Benoit <jerome.benoit@sap.com>