### PR TITLE
docker: do not expose ports used for internal communications.

### DIFF
--- a/docker-gcp/ev_server-production.Dockerfile
+++ b/docker-gcp/ev_server-production.Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /usr/app
 COPY --from=builder /usr/builder/node_modules ./node_modules
 COPY --from=builder /usr/builder/dist ./dist
 
-EXPOSE 80 81 8000 8010 8081 9090 9292
+EXPOSE 8000 8010 8081 9090 9292
 
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.5.0/wait /wait
 RUN chmod +x /wait


### PR DESCRIPTION
Signed-off-by: Jerome Benoit <jerome.benoit@sap.com>