### PR TITLE
#247-EMail-Change-the-URI-links-to-point-to-the-new-Dashboard

### DIFF
--- a/src/authorization/Authorizations.js
+++ b/src/authorization/Authorizations.js
@@ -148,7 +148,7 @@ class Authorizations {
           "chargeBoxID": chargingStation.getID(),
           "badgeId": tagID,
           "evseDashboardURL": Utils.buildEvseURL((await chargingStation.getTenant()).getSubdomain()),
-          "evseDashboardUserURL": await Utils.buildEvseUserURL(user)
+          "evseDashboardUserURL": await Utils.buildEvseUserURL(user, '#inerror')
         }
       );
       // Not authorized

--- a/src/server/ocpp/services/OCPPService.js
+++ b/src/server/ocpp/services/OCPPService.js
@@ -106,7 +106,7 @@ class OCPPService {
         {
           'chargeBoxID': updatedChargingStation.getID(),
           'evseDashboardURL': Utils.buildEvseURL((await updatedChargingStation.getTenant()).getSubdomain()),
-          'evseDashboardChargingStationURL': await Utils.buildEvseChargingStationURL(updatedChargingStation)
+          'evseDashboardChargingStationURL': await Utils.buildEvseChargingStationURL(updatedChargingStation, '#all')
         }
       );
       // Save Boot Notification
@@ -316,7 +316,7 @@ class OCPPService {
           'connectorId': statusNotification.connectorId,
           'error': `${statusNotification.status} - ${statusNotification.errorCode} - ${(statusNotification.info ? statusNotification.info : "N/A")}`,
           'evseDashboardURL': Utils.buildEvseURL((await chargingStation.getTenant()).getSubdomain()),
-          'evseDashboardChargingStationURL': await Utils.buildEvseChargingStationURL(chargingStation, statusNotification.connectorId)
+          'evseDashboardChargingStationURL': await Utils.buildEvseChargingStationURL(chargingStation, '#inerror')
         },
         {
           'connectorId': statusNotification.connectorId,
@@ -441,7 +441,7 @@ class OCPPService {
                   {minimumIntegerDigits: 1, minimumFractionDigits: 0, maximumFractionDigits: 2}),
                 'stateOfCharge': transaction.getCurrentStateOfCharge(),
                 'totalDuration': this._buildCurrentTransactionDuration(transaction),
-                'evseDashboardChargingStationURL': await Utils.buildEvseTransactionURL(chargingStation, transaction.getConnectorId(), transaction.getID()),
+                'evseDashboardChargingStationURL': await Utils.buildEvseTransactionURL(chargingStation, transaction.getID(), '#history'),
                 'evseDashboardURL': Utils.buildEvseURL((await chargingStation.getTenant()).getSubdomain())
               },
               transaction.getUserJson().locale,
@@ -470,7 +470,7 @@ class OCPPService {
                   (transaction.getUserJson().locale ? transaction.getUserJson().locale.replace('_', '-') : Constants.DEFAULT_LOCALE.replace('_', '-')),
                   {minimumIntegerDigits: 1, minimumFractionDigits: 0, maximumFractionDigits: 2}),
                 'stateOfCharge': transaction.getCurrentStateOfCharge(),
-                'evseDashboardChargingStationURL': await Utils.buildEvseTransactionURL(chargingStation, transaction.getConnectorId(), transaction.getID()),
+                'evseDashboardChargingStationURL': await Utils.buildEvseTransactionURL(chargingStation, transaction.getID(), '#history'),
                 'evseDashboardURL': Utils.buildEvseURL((await chargingStation.getTenant()).getSubdomain())
               },
               transaction.getUserJson().locale,
@@ -766,7 +766,7 @@ class OCPPService {
             'connectorId': transaction.getConnectorId(),
             'evseDashboardURL': Utils.buildEvseURL((await chargingStation.getTenant()).getSubdomain()),
             'evseDashboardChargingStationURL':
-              await Utils.buildEvseTransactionURL(chargingStation, transaction.getConnectorId(), transaction.getID())
+              await Utils.buildEvseTransactionURL(chargingStation, transaction.getID(), '#inprogress')
           },
           user.getLocale(),
           {
@@ -957,7 +957,7 @@ class OCPPService {
           'totalDuration': this._buildTransactionDuration(transaction),
           'totalInactivity': this._buildTransactionInactivity(transaction),
           'stateOfCharge': transaction.getEndStateOfCharge(),
-          'evseDashboardChargingStationURL': await Utils.buildEvseTransactionURL(chargingStation, transaction.getConnectorId(), transaction.getID()),
+          'evseDashboardChargingStationURL': await Utils.buildEvseTransactionURL(chargingStation, transaction.getID(), '#history'),
           'evseDashboardURL': Utils.buildEvseURL((await chargingStation.getTenant()).getSubdomain())
         },
         user.getLocale(),

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -248,34 +248,25 @@ class Utils {
       _centralSystemFrontEndConfig.port}`;
   }
 
-  static async buildEvseUserURL(user) {
+  static async buildEvseUserURL(user, hash = '') {
     const tenant = await user.getTenant();
     const _evseBaseURL = Utils.buildEvseURL(tenant.getSubdomain());
     // Add
-    return _evseBaseURL + "/#/pages/users/user/" + user.getID();
+    return _evseBaseURL + "/users?UserID=" + user.getID() + hash;
   }
 
-  static async buildEvseChargingStationURL(chargingStation, connectorId = null) {
+  static async buildEvseChargingStationURL(chargingStation, hash = '') {
     const tenant = await chargingStation.getTenant();
     const _evseBaseURL = Utils.buildEvseURL(tenant.getSubdomain());
 
-    // Connector provided?
-    if (connectorId > 0) {
-      // URL with connector
-      return _evseBaseURL + "/#/pages/chargers/charger/" + chargingStation.getID() +
-        "/connector/" + connectorId;
-    } else {
-      // URL with charger only
-      return _evseBaseURL + "/#/pages/chargers/charger/" + chargingStation.getID();
-    }
+    return _evseBaseURL + "/charging-stations?ChargingStationID=" + chargingStation.getID() + hash;
   }
 
-  static async buildEvseTransactionURL(chargingStation, connectorId, transactionId) {
+  static async buildEvseTransactionURL(chargingStation, transactionId, hash = "") {
     const tenant = await chargingStation.getTenant();
     const _evseBaseURL = Utils.buildEvseURL(tenant.getSubdomain());
     // Add
-    return _evseBaseURL + "/#/pages/chargers/charger/" + chargingStation.getID() +
-      "/connector/" + connectorId + "/transaction/" + transactionId;
+    return _evseBaseURL + "/transactions?TransactionID=" + transactionId + hash;
   }
 
   static isServerInProductionMode() {


### PR DESCRIPTION
Il y a 4 scénarios implémentés pour l'instant 

Début de transaction => envoi email dans "In progress"
Fin de session => envoi email dans "History"
Début transaction avec utilisateur sans badge => envoi email dans "In error"
Chargeur connecté => envoi Email dans "All"