### PR TITLE
Use the same body limit size for all body parsers in servers.

### DIFF
--- a/src/server/ExpressTools.js
+++ b/src/server/ExpressTools.js
@@ -29,7 +29,9 @@ module.exports = {
       limit: bodyLimit
     }));
     app.use(hpp());
-    app.use(bodyParser.xml());
+    app.use(bodyParser.xml({
+      limit: bodyLimit
+    }));
     // Use
     app.use(locale(Configuration.getLocalesConfig().supported));
     // Check Cloud Foundry


### PR DESCRIPTION
Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>