### PR TITLE
Use empty arrays instead of undefined for authorized entities.

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -6,7 +6,7 @@
   ],
   "opts": "./test/mocha.opts",
   "package": "./package.json",
-  "reporter": "mochasome",
+  "reporter": "mochawesome",
   "reporter-options": "reportDir=outputs/mochawesome-report,json=false",
   "slow": 75,
   "timeout": 2000,

--- a/src/authorization/AuthorizationsDefinition.ts
+++ b/src/authorization/AuthorizationsDefinition.ts
@@ -138,6 +138,10 @@ const GRANTS = {
           'GetDiagnostics', 'UpdateFirmware'], attributes: ['*'],
         condition: { Fn: 'LIST_CONTAINS', args: { 'sites': '$.site' } }
       },
+      {
+        resource: 'Transaction', action: 'Read', attributes: ['*'],
+        condition: { Fn: 'LIST_CONTAINS', args: { 'sites': '$.site' } }
+      },
       { resource: 'Loggings', action: 'List', attributes: ['*'] },
       { resource: 'Logging', action: 'Read', attributes: ['*'], args: { 'sites': '$.site' } },
     ]

--- a/test/api/OCPPValidationTest.ts
+++ b/test/api/OCPPValidationTest.ts
@@ -2,6 +2,7 @@ import chai, { expect } from 'chai';
 import chaiDatetime from 'chai-datetime';
 import chaiSubset from 'chai-subset';
 import faker from 'faker';
+import 'mocha';
 import moment from 'moment';
 import CentralServerService from './client/CentralServerService';
 import DataHelper from './DataHelper';


### PR DESCRIPTION
- Use empty arrays instead of undefined for authorized entities.
- Rename and fixed mocharc.json to .mocharc.json