### PR TITLE
fixed (please review)

### DIFF
--- a/src/storage/mongodb/UserStorage.ts
+++ b/src/storage/mongodb/UserStorage.ts
@@ -148,13 +148,13 @@ export default class UserStorage {
     return user.count > 0 ? user.result[0] : null;
   }
 
-  public static async getUser(tenantID: string, userID: string): Promise<User> {
+  public static async getUser(tenantID: string, id: string): Promise<User> {
     // Debug
     const uniqueTimerID = Logging.traceStart('UserStorage', 'getUser');
     // Get user
-    const user = await UserStorage.getUsers(tenantID, { userID: userID }, Constants.DB_PARAMS_SINGLE_RECORD);
+    const user = await UserStorage.getUsers(tenantID, { search: id }, Constants.DB_PARAMS_SINGLE_RECORD);
     // Debug
-    Logging.traceEnd('UserStorage', 'getUser', uniqueTimerID, { userID });
+    Logging.traceEnd('UserStorage', 'getUser', uniqueTimerID, { id });
     return user.count > 0 ? user.result[0] : null;
   }
 
@@ -324,49 +324,42 @@ export default class UserStorage {
     // Check Skip
     skip = Utils.checkRecordSkip(skip);
     const filters: any = {
-      '$and': [
-        {
-          '$or': DatabaseUtils.getNotDeletedFilter()
-        }
-      ]
+      '$and': [{
+        '$or': DatabaseUtils.getNotDeletedFilter()
+      }]
     };
     // Source?
     if (params.search) {
       if (ObjectID.isValid(params.search)) {
-        filters.$and.push({id: params.search});
+        filters.$and.push({ _id: Utils.convertToObjectID(params.search) });
       } else {
         // Build filter
         filters.$and.push({
           '$or': [
             { 'name': { $regex: params.search, $options: 'i' } },
             { 'firstName': { $regex: params.search, $options: 'i' } },
-            { 'tagIDs': { $elemMatch: { $regex: params.search, $options: 'i' } } },
+            { 'tagIDs': { $regex: params.search, $options: 'i' } },
             { 'email': { $regex: params.search, $options: 'i' } },
             { 'plateID': { $regex: params.search, $options: 'i' } }
           ]
         });
       }
     }
-    // Query by Email
+    // Email
     if (params.email) {
       filters.$and.push({
         'email': params.email
       });
     }
-    // UserID: Used only with SiteID
-    if (params.userID) {
-      filters.$and.push({
-        '_id': Utils.convertToObjectID(params.userID)
-      });
-    }
-    // Query by role
+    // Role
     if (params.roles && Array.isArray(params.roles) && params.roles.length > 0) {
       filters.role = { $in: params.roles };
     }
-    // Query by status (Previously getUsersInError)
+    // Status (Previously getUsersInError)
     if (params.statuses && Array.isArray(params.statuses) && params.statuses.length > 0) {
       filters.status = { $in: params.statuses };
     }
+    // Notification
     if (params.notificationsActive) {
       filters.$and.push({
         'notificationsActive': params.notificationsActive
@@ -395,6 +388,12 @@ export default class UserStorage {
         }
       }
     });
+    // Filters
+    if (filters) {
+      aggregation.push({
+        $match: filters
+      });
+    }
     // Add Site
     if (params.siteIDs || params.excludeSiteID) {
       DatabaseUtils.pushSiteUserLookupInAggregation({
@@ -419,12 +418,6 @@ export default class UserStorage {
     }
     // Change ID
     DatabaseUtils.renameDatabaseID(aggregation);
-    // Filters
-    if (filters) {
-      aggregation.push({
-        $match: filters
-      });
-    }//TODO separate filters in the future for optimal performance
     // Limit records?
     if (!onlyRecordCount) {
       // Always limit the nbr of record to avoid perfs issues


### PR DESCRIPTION
The code attempted to regex match an ObjectID, and tags in the earliest aggregation stage, where the tags hadn't even been added yet and the ObjectID not converted yet.
By slightly adapting the filtering query to match the format of the tags, as well as moving it after the stages that have added the tags onto the documents, the problem disappears.

However, one question remains: Do we separate the search filter into two, such that some of the searches can already be performed before the other aggregation stages (Thus saving a little bit of performance), or do we keep it more readable by having all filters stay together, although this will entail a small decrease in performance (not measured, and shouldn't be much, but basically we might be performing one unnecessary lookup at times)

No other class has the same problem, as objectIDs are not partially matched - instead, it is checked whether the search is a full, correct, objectId. Please determine whether you'd like to adopt the same way of checking in user, or if it is better to have a partial search.