### PR TITLE
Add tests to ensure that it's not possible to request an activation link in the Super Tenant

### DIFF
--- a/src/notification/email/EMailNotificationTask.ts
+++ b/src/notification/email/EMailNotificationTask.ts
@@ -127,8 +127,12 @@ export default class EMailNotificationTask extends NotificationTask {
     // Render the subject
     emailTemplate.subject = ejs.render(emailTemplate.subject, data);
     // Render the tenant name
-    const tenant = await Tenant.getTenant(tenantID);
-    emailTemplate.tenant = tenant.getName();
+    if (tenantID !== Constants.DEFAULT_TENANT) {
+      const tenant = await Tenant.getTenant(tenantID);
+      emailTemplate.tenant = tenant.getName();
+    } else {
+      emailTemplate.tenant = Constants.DEFAULT_TENANT;
+    }
     // Render Base URL
     emailTemplate.baseURL = ejs.render(emailTemplate.baseURL, data);
     emailTemplate.body.template = templateName;

--- a/src/server/rest/service/AuthService.ts
+++ b/src/server/rest/service/AuthService.ts
@@ -654,6 +654,14 @@ export default class AuthService {
       return;
     }
 
+    // Check that this is not the super tenant
+    if (tenantID === Constants.DEFAULT_TENANT) {
+      throw new AppError(
+        Constants.CENTRAL_SERVER,
+        'Cannot verify email in the Super Tenant', Constants.HTTP_GENERAL_ERROR,
+        'AuthService', 'handleVerifyEmail');
+    }
+
     // Check email
     if (!filteredRequest.Email) {
       throw new AppError(

--- a/test/api/AuthenticationTest.ts
+++ b/test/api/AuthenticationTest.ts
@@ -244,6 +244,18 @@ describe('Authentication Service', function() {
       expect(response.status).to.be.eql(550);
       expect(response.data).to.not.have.property('token');
     });
+
+    it('should not be possible to verify email for the Super Tenant', async () => {
+      const response = await CentralServerService.DefaultInstance.authenticationApi.verifyEmail('unknown@sap.com', 'unknownVerificationToken', '');
+      expect(response.status).to.be.eql(500);
+      expect(response.data.message).to.be.eq('Cannot verify email in the Super Tenant');
+    });
+
+    it('should not be possible to request verification email for the Super Tenant', async () => {
+      const response = await CentralServerService.DefaultInstance.authenticationApi.resendVerificationEmail('unknown@sap.com', '');
+      expect(response.status).to.be.eql(500);
+      expect(response.data.message).to.be.eq('Cannot request a verification Email in the Super Tenant');
+    });
   });
 });
 

--- a/test/api/client/AuthenticationApi.ts
+++ b/test/api/client/AuthenticationApi.ts
@@ -65,5 +65,41 @@ export default class AuthenticationApi {
     });
     return response;
   }
+
+  public async resendVerificationEmail(email, tenant = '') {
+    const data = {
+      email: email,
+      tenant: tenant,
+      captcha: '03AMGVjXiyflPJpUOJF-AW2YP9-uQZvbVKsnx2CaESTX7mr59laYB0KKn7QERpWk-cadi1e2D0oYyjClv6UcYJ3IrYI951f2uopiLQv8ykAKEz3TQ3ZWgYJQSvItSZ7cd8wSFl7EF9aVEIHJobWg4OljtmSf2YUyXFnma76ih089LfUe0uSQC8piAT6DJ5WVcNaR827jbJrzCtYSPFX8u_GSFM6jCQU0RdnFgTuFIst2hyZ_FfiKJSpG9pSF2avSie1R-y6PVJktxNHdDaTuN4PK-AucjKrHSO9A'
+    };
+    // Send
+    const response = await this._baseApi.send({
+      method: 'POST',
+      url: '/client/auth/ResendVerificationEmail',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      data: data
+    });
+    return response;
+  }
+
+  public async verifyEmail(email, verificationToken, tenant = '') {
+    const data = {
+      Email: email,
+      tenant: tenant,
+      VerificationToken: verificationToken
+    };
+    // Send
+    const response = await this._baseApi.send({
+      method: 'GET',
+      url: '/client/auth/VerifyEmail',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      data: data
+    });
+    return response;
+  }
 }
 


### PR DESCRIPTION
- Add tests to ensure that it's not possible to request an activation link in the Super Tenant
- Reject calls to verifyEmail in the Super Tenant

![Screen Shot 2019-07-25 at 17 38 34](https://user-images.githubusercontent.com/9685252/61888040-17c41580-af03-11e9-8a7e-54882f275121.png)
