### PR TITLE
Fix of issue #679

### DIFF
--- a/test/api/DataHelper.ts
+++ b/test/api/DataHelper.ts
@@ -31,7 +31,8 @@ export default class DataHelper {
       siteAreas: [],
       sites: [],
       companies: [],
-      users: []
+      users: [],
+      transactionsStarted: []
     };
   }
 
@@ -112,15 +113,18 @@ export default class DataHelper {
       await this.centralServerService.deleteEntity(
         this.centralServerService.companyApi, company);
     }
+    for (const transaction of this.context.transactionsStarted) {
+      await this.centralServerService.transactionApi.delete(transaction);
+    }
     for (const chargingStation of this.context.chargingStations) {
       await this.centralServerService.deleteEntity(
         this.centralServerService.chargingStationApi, chargingStation);
     }
   }
 
-  public close() {
+  public async close() {
     if (this.ocpp && this.ocpp.closeConnection) {
-      this.ocpp.closeConnection();
+      await this.ocpp.closeConnection();
     }
   }
 
@@ -161,6 +165,7 @@ export default class DataHelper {
     expect(response.data).to.have.property('transactionId');
     if (expectedStatus === 'Accepted') {
       expect(response.data.transactionId).to.not.equal(0);
+      this.context.transactionsStarted.push(response.data.transactionId);
     } else {
       expect(response.data.transactionId).to.equal(0);
     }

--- a/test/api/OCPPAllVersionsTest.ts
+++ b/test/api/OCPPAllVersionsTest.ts
@@ -22,7 +22,7 @@ class TestData {
 
 const testData: TestData = new TestData();
 
-describe('OCPP tests (all versions)', function () {
+describe('OCPP tests (all versions)', function() {
   this.timeout(300000); // Will automatically stop the unit test after that period of time
 
   before(async () => {

--- a/test/api/OCPPCommonTests.ts
+++ b/test/api/OCPPCommonTests.ts
@@ -14,7 +14,7 @@ export default class OCPPCommonTests {
   public tenantContext: any;
   public chargingStationContext: ChargingStationContext;
   public centralUserContext: any;
-  public centralUserService: any;
+  public centralUserService: CentralServerService;
 
   public currentPricingSetting;
   public priceKWH = 2;
@@ -78,7 +78,7 @@ export default class OCPPCommonTests {
   }
 
   public async before() {
-    const allSettings = await this.centralUserService.settingApi.readAll();
+    const allSettings = await this.centralUserService.settingApi.readAll({});
     this.currentPricingSetting = allSettings.data.result.find((s) => {
       return s.identifier === 'pricing';
     });


### PR DESCRIPTION
The Transaction test unit is still not yet adjusted. But I have already fixed the following problems:
* changing the pricing settings (it was changed from 1 to 1,5 EUR in one test, which was causing the failure of the 2 reported expect checks)
* creating new transactions (I now remove all created transactions at the end)

However, this old test unit still leaves a lot of created meter values and new charging stations in the test tenant! 

I will convert this test unit as soon as I can...