### PR TITLE
Remove id from creation schema.

### DIFF
--- a/src/assets/server/rest/schemas/tenant/tenant-creation.json
+++ b/src/assets/server/rest/schemas/tenant/tenant-creation.json
@@ -3,11 +3,6 @@
     "description": "describes properties required to create a tenant",
     "type": "object",
     "properties": {
-        "id": {
-            "type": "string",
-            "description": "identifier of the tenant",
-            "pattern": "^[0-9a-fA-F]{24}$"
-        },
         "name": {
             "type": "string",
             "description": "name of the tenant",


### PR DESCRIPTION
ID is generated by the server, so it should be provided in the payload.

#745 