### PR TITLE
#810 Ensure that the timestamp from the transation is taken as a Date to

### DIFF
--- a/src/integration/pricing/convergent-charging/ConvergentChargingPricing.ts
+++ b/src/integration/pricing/convergent-charging/ConvergentChargingPricing.ts
@@ -61,7 +61,8 @@ export default class ConvergentChargingPricing extends Pricing<ConvergentChargin
 
   computeSessionId(consumptionData) {
 
-    const dataId = consumptionData.userID + consumptionData.chargeBoxID + consumptionData.connectorId + this.transaction.timestamp;
+    const timestamp = this.transaction.timestamp instanceof Date ? this.transaction.timestamp : new Date(this.transaction.timestamp);
+    const dataId = consumptionData.userID + consumptionData.chargeBoxID + consumptionData.connectorId + timestamp.toISOString();
 
     let hash = 0, i, chr;
     if (dataId.length === 0) {


### PR DESCRIPTION
During the start of the transaction, it has not been saved yet and its timestamp is of type `string`. When fetching it from the DB it is a `Date` type.
It leads to the following difference when concatenating values : 
* `5c62a24a084dd543fd640ff3SIMU12019-09-06T16:33:06+02:00` during the start of the transaction
* `5c62a24a084dd543fd640ff3SIMU1Fri Sep 06 2019 16:33:06 GMT+0200 (Central European Summer Time)` for each update

The solution proposed is to check the type of timestamp prior to compute the sessionId to always have the same behavior.

_Originally posted by @mehdijouan in https://github.com/LucasBrazi06/ev-server/issues/810#issuecomment-528885488_