### PR TITLE
Allow to ping an ocpi endpoint without ID. (before creation) + Mandatory role

### DIFF
--- a/src/server/rest/service/OCPIEndpointService.ts
+++ b/src/server/rest/service/OCPIEndpointService.ts
@@ -195,7 +195,6 @@ export default class OCPIEndpointService {
     }
     // Filter
     const filteredRequest = OCPIEndpointSecurity.filterOcpiEndpointPingRequest(req.body);
-    UtilsService.assertIdIsProvided(filteredRequest.id, MODULE_NAME, 'handlePingOcpiEndpoint', req.user);
     // Check Mandatory fields
     Utils.checkIfOCPIEndpointValid(filteredRequest, req);
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -734,6 +734,16 @@ export default class Utils {
         user: req.user.id
       });
     }
+    if (!ocpiEndpoint.role) {
+      throw new AppError({
+        source: Constants.CENTRAL_SERVER,
+        errorCode: Constants.HTTP_GENERAL_ERROR,
+        message: 'The OCPI Endpoint role is mandatory',
+        module: 'Utils',
+        method: 'checkIfOCPIEndpointValid',
+        user: req.user.id
+      });
+    }
     if (!ocpiEndpoint.baseUrl) {
       throw new AppError({
         source: Constants.CENTRAL_SERVER,


### PR DESCRIPTION
- Allow to ping an ocpi endpoint without ID. (before creation).
- Make OCPI role mandatory