### PR TITLE
Fix a build error in src/server/ocpp/utils/OCPPUtils.ts.

### DIFF
--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -52,7 +52,6 @@ export default class OCPPUtils {
         chargingStation.connectors = foundTemplate.template.connectors;
       }
       // Handle capabilities
-      chargingStation.capabilities = {};
       if (foundTemplate.template.hasOwnProperty('capabilities')) {
         let matchFirmware = true;
         let matchOcpp = true;


### PR DESCRIPTION
Do not initlialize typed object to empty literal.

Signed-off-by: Jerome Benoit <jerome.benoit@sap.com>