### PR TITLE
replaced hasOwnProperty everywhere

### DIFF
--- a/src/migration/tasks/MigrateCoordinatesTask.ts
+++ b/src/migration/tasks/MigrateCoordinatesTask.ts
@@ -24,7 +24,7 @@ export default class MigrateCoordinatesTask extends MigrationTask {
       []).toArray();
     // Process each setting
     for (const company of companies) {
-      if (company.address && company.address.hasOwnProperty('longitude') && company.address.hasOwnProperty('latitude')) {
+      if (company.address && Utils.objectHasProperty(company.address, 'longitude') && Utils.objectHasProperty(company.address, 'latitude')) {
         if (company.address.longitude && company.address.latitude) {
           company.address.coordinates = [
             Utils.convertToFloat(company.address.longitude),
@@ -57,7 +57,7 @@ export default class MigrateCoordinatesTask extends MigrationTask {
       []).toArray();
     // Process each setting
     for (const site of sites) {
-      if (site.address && site.address.hasOwnProperty('longitude') && site.address.hasOwnProperty('latitude')) {
+      if (site.address && Utils.objectHasProperty(site.address, 'longitude') && Utils.objectHasProperty(site.address, 'latitude')) {
         if (site.address.longitude && site.address.latitude) {
           site.address.coordinates = [
             Utils.convertToFloat(site.address.longitude),
@@ -90,7 +90,7 @@ export default class MigrateCoordinatesTask extends MigrationTask {
       []).toArray();
     // Process each setting
     for (const sitearea of siteareas) {
-      if (sitearea.address && sitearea.address.hasOwnProperty('longitude') && sitearea.address.hasOwnProperty('latitude')) {
+      if (sitearea.address && Utils.objectHasProperty(sitearea.address, 'longitude') && Utils.objectHasProperty(sitearea.address, 'latitude')) {
         if (sitearea.address.longitude && sitearea.address.latitude) {
           sitearea.address.coordinates = [
             Utils.convertToFloat(sitearea.address.longitude),
@@ -123,7 +123,7 @@ export default class MigrateCoordinatesTask extends MigrationTask {
       []).toArray();
     // Process each setting
     for (const user of users) {
-      if (user.address && user.address.hasOwnProperty('longitude') && user.address.hasOwnProperty('latitude')) {
+      if (user.address && Utils.objectHasProperty(user.address, 'longitude') && Utils.objectHasProperty(user.address, 'latitude')) {
         if (user.address.longitude && user.address.latitude) {
           user.address.coordinates = [
             Utils.convertToFloat(user.address.longitude),
@@ -156,7 +156,7 @@ export default class MigrateCoordinatesTask extends MigrationTask {
       []).toArray();
     // Process each setting
     for (const chargingstation of chargingstations) {
-      if (chargingstation.hasOwnProperty('longitude') && chargingstation.hasOwnProperty('latitude')) {
+      if (Utils.objectHasProperty(chargingstation, 'longitude') && Utils.objectHasProperty(chargingstation, 'latitude')) {
         if (chargingstation.longitude && chargingstation.latitude) {
           chargingstation.coordinates = [
             Utils.convertToFloat(chargingstation.longitude),

--- a/src/migration/tasks/UpdateChargingStationTemplatesTask.ts
+++ b/src/migration/tasks/UpdateChargingStationTemplatesTask.ts
@@ -7,6 +7,7 @@ import Constants from '../../utils/Constants';
 import Logging from '../../utils/Logging';
 import MigrationTask from '../MigrationTask';
 import global from './../../types/GlobalType';
+import Utils from "../../utils/Utils";
 
 export default class UpdateChargingStationTemplatesTask extends MigrationTask {
   async migrate() {
@@ -43,7 +44,7 @@ export default class UpdateChargingStationTemplatesTask extends MigrationTask {
       }
       // Check Connectors
       for (const connector of chargingStationMDB.connectors) {
-        if (!connector.hasOwnProperty('amperageLimit')) {
+        if (!Utils.objectHasProperty(connector, 'amperageLimit')) {
           connector.amperageLimit = connector.amperage;
           chargingStationUpdated = true;
         }

--- a/src/notification/email/EMailNotificationTask.ts
+++ b/src/notification/email/EMailNotificationTask.ts
@@ -240,7 +240,8 @@ export default class EMailNotificationTask implements NotificationTask {
       }, data, tenant, user, severity, retry);
     } catch (error) {
       Logging.logError({
-        tenantID: tenant.id, source: (data.hasOwnProperty('chargeBoxID') ? data.chargeBoxID : undefined),
+        tenantID: tenant.id,
+        source: (Utils.objectHasProperty(data, 'chargeBoxID') ? data.chargeBoxID : undefined),
         module: 'EMailNotificationTask', method: 'prepareAndSendEmail',
         action: 'SendEmail',
         message: 'Error in preparing email for user',
@@ -278,7 +279,8 @@ export default class EMailNotificationTask implements NotificationTask {
         // Log
         try {
           Logging.logError({
-            tenantID: tenant.id, source: (data.hasOwnProperty('chargeBoxID') ? data.chargeBoxID : undefined),
+            tenantID: tenant.id,
+            source: (Utils.objectHasProperty(data, 'chargeBoxID') ? data.chargeBoxID : undefined),
             module: 'EMailNotificationTask', method: 'sendEmail',
             action: (!retry ? 'SendEmail' : 'SendEmailBackup'),
             message: `Error Sending Email (${messageToSend.from}): '${messageToSend.subject}'`,
@@ -308,7 +310,7 @@ export default class EMailNotificationTask implements NotificationTask {
         // Email sent successfully
         Logging.logInfo({
           tenantID: tenant.id,
-          source: (data.hasOwnProperty('chargeBoxID') ? data.chargeBoxID : undefined),
+          source: (Utils.objectHasProperty(data, 'chargeBoxID') ? data.chargeBoxID : undefined),
           module: 'EMailNotificationTask', method: 'prepareAndSendEmail',
           action: (!retry ? 'SendEmail' : 'SendEmailBackup'),
           actionOnUser: user,

--- a/src/notification/remote-push-notification/RemotePushNotificationTask.ts
+++ b/src/notification/remote-push-notification/RemotePushNotificationTask.ts
@@ -294,7 +294,7 @@ export default class RemotePushNotificationTask implements NotificationTask {
     if (!user || !user.mobileToken || user.mobileToken.length === 0) {
       Logging.logWarning({
         tenantID: tenant.id,
-        source: (data && data.hasOwnProperty('chargeBoxID') ? data['chargeBoxID'] : null),
+        source: (data && Utils.objectHasProperty(data, 'chargeBoxID') ? data['chargeBoxID'] : null),
         module: 'RemotePushNotificationTask', method: 'sendRemotePushNotificationToUsers',
         message: `'${notificationType}': No mobile token found for this User`,
         actionOnUser: user.id,
@@ -315,7 +315,7 @@ export default class RemotePushNotificationTask implements NotificationTask {
       // Response is a message ID string.
       Logging.logInfo({
         tenantID: tenant.id,
-        source: (data && data.hasOwnProperty('chargeBoxID') ? data['chargeBoxID'] : null),
+        source: (data && Utils.objectHasProperty(data, 'chargeBoxID') ? data['chargeBoxID'] : null),
         module: 'RemotePushNotificationTask', method: 'sendRemotePushNotificationToUsers',
         message: `Notification Sent: '${notificationType}' - '${title}'`,
         actionOnUser: user.id,
@@ -325,7 +325,7 @@ export default class RemotePushNotificationTask implements NotificationTask {
     }).catch((error) => {
       Logging.logError({
         tenantID: tenant.id,
-        source: (data && data.hasOwnProperty('chargeBoxID') ? data['chargeBoxID'] : null),
+        source: (data && Utils.objectHasProperty(data, 'chargeBoxID') ? data['chargeBoxID'] : null),
         module: 'RemotePushNotificationTask', method: 'sendRemotePushNotificationToUsers',
         message: `Error when sending Notification: '${notificationType}' - '${error.message}'`,
         actionOnUser: user.id,

--- a/src/server/ocpp/services/OCPPService.ts
+++ b/src/server/ocpp/services/OCPPService.ts
@@ -380,7 +380,7 @@ export default class OCPPService {
     // OCPP 1.6: Finishing --> Available
     if (connector.status === ChargePointStatus.FINISHING &&
       statusNotification.status === ChargePointStatus.AVAILABLE &&
-      statusNotification.hasOwnProperty('timestamp')) {
+        Utils.objectHasProperty(statusNotification, 'timestamp')) {
       // Get the last transaction
       const lastTransaction = await TransactionStorage.getLastTransaction(
         tenantID, chargingStation.id, connector.connectorId);

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -27,7 +27,7 @@ export default class OCPPUtils {
       // Browse filter for extra matching
       for (const filter in chargingStationTemplate.extraFilters) {
         // Check
-        if (chargingStationTemplate.extraFilters.hasOwnProperty(filter)) {
+        if (Utils.objectHasProperty(chargingStationTemplate.extraFilters, filter)) {
           const filterValue: string = chargingStationTemplate.extraFilters[filter];
           if (!(new RegExp(filterValue).test(chargingStation[filter]))) {
             foundTemplate = null;
@@ -49,18 +49,18 @@ export default class OCPPUtils {
     // Copy from template
     if (chargingStationTemplate) {
       // Assign props
-      if (chargingStationTemplate.template.hasOwnProperty('cannotChargeInParallel')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'cannotChargeInParallel')) {
         chargingStation.cannotChargeInParallel = chargingStationTemplate.template.cannotChargeInParallel;
       }
-      if (chargingStationTemplate.template.hasOwnProperty('maximumPower')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'maximumPower')) {
         chargingStation.maximumPower = chargingStationTemplate.template.maximumPower;
       }
-      if (chargingStationTemplate.template.hasOwnProperty('currentType')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'currentType')) {
         chargingStation.currentType = chargingStationTemplate.template.currentType;
       }
       // Handle capabilities
       chargingStation.capabilities = {} as ChargingStationCapabilities;
-      if (chargingStationTemplate.template.hasOwnProperty('capabilities')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'capabilities')) {
         let matchFirmware = true;
         let matchOcpp = true;
         // Search Firmware/Ocpp match
@@ -82,7 +82,7 @@ export default class OCPPUtils {
       }
       // Handle OCPP Advanced Commands
       chargingStation.ocppAdvancedCommands = [];
-      if (chargingStationTemplate.template.hasOwnProperty('ocppAdvancedCommands')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'ocppAdvancedCommands')) {
         let matchFirmware = true;
         let matchOcpp = true;
         // Search Firmware/Ocpp match
@@ -104,7 +104,7 @@ export default class OCPPUtils {
       }
       // Handle OCPP Standard Parameters
       chargingStation.ocppStandardParameters = [];
-      if (chargingStationTemplate.template.hasOwnProperty('ocppStandardParameters')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'ocppStandardParameters')) {
         let matchOcpp = true;
         // Search Firmware/Ocpp match
         for (const ocppStandardParameters of chargingStationTemplate.template.ocppStandardParameters) {
@@ -126,7 +126,7 @@ export default class OCPPUtils {
       }
       // Handle OCPP Vendor Parameters
       chargingStation.ocppVendorParameters = [];
-      if (chargingStationTemplate.template.hasOwnProperty('ocppVendorParameters')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'ocppVendorParameters')) {
         let matchFirmware = true;
         let matchOcpp = true;
         // Search Firmware/Ocpp match
@@ -179,7 +179,7 @@ export default class OCPPUtils {
     // Copy from template
     if (chargingStationTemplate) {
       // Handle connector
-      if (chargingStationTemplate.template.hasOwnProperty('connectors')) {
+      if (Utils.objectHasProperty(chargingStationTemplate.template, 'connectors')) {
         // Find the connector in the template
         const templateConnector = chargingStationTemplate.template.connectors.find(
           (connector) => connector.connectorId === connectorID);
@@ -237,7 +237,7 @@ export default class OCPPUtils {
       return;
     }
     for (const connector of chargingStation.connectors) {
-      if (connector.hasOwnProperty('power')) {
+      if (Utils.objectHasProperty(connector, 'power')) {
         maximumPower += connector.power;
       }
     }

--- a/src/server/ocpp/validation/OCPPValidation.ts
+++ b/src/server/ocpp/validation/OCPPValidation.ts
@@ -106,7 +106,7 @@ export default class OCPPValidation extends SchemaValidator {
       (connector) => connector.connectorId === meterValues.connectorId);
     const chargerTransactionId = Utils.convertToInt(foundConnector ? foundConnector.activeTransactionID : 0);
     // Transaction is provided in MeterValue?
-    if (meterValues.hasOwnProperty('transactionId')) {
+    if (Utils.objectHasProperty(meterValues, 'transactionId')) {
       // Always integer
       meterValues.transactionId = Utils.convertToInt(meterValues.transactionId);
       // Yes: Check Transaction ID (ABB)

--- a/src/server/odata/odata-entities/ODataBootNotifications.ts
+++ b/src/server/odata/odata-entities/ODataBootNotifications.ts
@@ -1,5 +1,6 @@
 
 import AbstractODataEntities from './AbstractODataEntities';
+import Utils from "../../../utils/Utils";
 
 export default class ODataBootNotifications extends AbstractODataEntities {
   public buildParams: any;
@@ -29,10 +30,10 @@ export default class ODataBootNotifications extends AbstractODataEntities {
   public convert(object, req) {
     const bootNotification = super.convert(object, req);
     // Convert id name
-    if (bootNotification.hasOwnProperty('_id')) {
+    if (Utils.objectHasProperty(bootNotification, '_id')) {
       bootNotification.id = bootNotification._id;
     }
-    if (bootNotification.hasOwnProperty('timestamp') && bootNotification.timestamp) {
+    if (Utils.objectHasProperty(bootNotification, 'timestamp') && bootNotification.timestamp) {
       // Convert timestamp and build date object
       bootNotification.timestamp = this.convertTimestamp(bootNotification.timestamp, req);
       bootNotification.bootDate = this.buildDateObject(bootNotification.timestamp, req);

--- a/src/server/odata/odata-entities/ODataStatusNotifications.ts
+++ b/src/server/odata/odata-entities/ODataStatusNotifications.ts
@@ -1,5 +1,6 @@
 
 import AbstractODataEntities from './AbstractODataEntities';
+import Utils from "../../../utils/Utils";
 
 export default class ODataStatusNotifications extends AbstractODataEntities {
   public buildParams: any;
@@ -29,10 +30,10 @@ export default class ODataStatusNotifications extends AbstractODataEntities {
   public convert(object, req) {
     const statusNotification = super.convert(object, req);
     // Convert id name
-    if (statusNotification.hasOwnProperty('_id')) {
+    if (Utils.objectHasProperty(statusNotification, '_id')) {
       statusNotification.id = statusNotification._id;
     }
-    if (statusNotification.hasOwnProperty('timestamp') && statusNotification.timestamp) {
+    if (Utils.objectHasProperty(statusNotification, 'timestamp') && statusNotification.timestamp) {
       // Convert timestamp and build date object
       statusNotification.timestamp = this.convertTimestamp(statusNotification.timestamp, req);
       statusNotification.notificationDate = this.buildDateObject(statusNotification.timestamp, req);

--- a/src/server/odata/odata-entities/ODataTransactions.ts
+++ b/src/server/odata/odata-entities/ODataTransactions.ts
@@ -1,4 +1,5 @@
 import AbstractODataEntities from './AbstractODataEntities';
+import Utils from "../../../utils/Utils";
 
 export default class ODataTransactions extends AbstractODataEntities {
   public buildParams: any;
@@ -28,7 +29,7 @@ export default class ODataTransactions extends AbstractODataEntities {
   //   - shorten stop price to 15 in order to be compatible with Edm.Double
   public convert(object, req) {
     const transaction = super.convert(object, req);
-    if (transaction.hasOwnProperty('timestamp') && transaction.timestamp) {
+    if (Utils.objectHasProperty(transaction, 'timestamp') && transaction.timestamp) {
       // Convert timestamp and build date object
       transaction.timestamp = this.convertTimestamp(transaction.timestamp, req);
       transaction.startDate = this.buildDateObject(transaction.timestamp, req);
@@ -40,12 +41,12 @@ export default class ODataTransactions extends AbstractODataEntities {
       delete transaction['user'];
     }
     // Rename TagID
-    if (transaction.hasOwnProperty('tagID')) {
+    if (Utils.objectHasProperty(transaction, 'tagID')) {
       transaction.startTagID = transaction.tagID;
       delete transaction['tagID'];
     }
     if (transaction.stop) {
-      if (transaction.stop.hasOwnProperty('timestamp') && transaction.stop.timestamp) {
+      if (Utils.objectHasProperty(transaction.stop, 'timestamp') && transaction.stop.timestamp) {
         // Convert timestamp and build date object
         transaction.stop.timestamp = this.convertTimestamp(transaction.stop.timestamp, req);
         transaction.stopDate = this.buildDateObject(transaction.stop.timestamp, req);
@@ -57,11 +58,11 @@ export default class ODataTransactions extends AbstractODataEntities {
         delete transaction.stop['user'];
       }
       // Rename TagID and move to transaction root
-      if (transaction.stop.hasOwnProperty('tagID')) {
+      if (Utils.objectHasProperty(transaction.stop, 'tagID')) {
         transaction.stopTagID = transaction.stop.tagID;
         delete transaction.stop['tagID'];
       }
-      if (transaction.stop.hasOwnProperty('price')) {
+      if (Utils.objectHasProperty(transaction.stop, 'price')) {
         transaction.stop.price = transaction.stop.price.toFixed(15);
       }
     }

--- a/src/server/rest/service/ChargingStationService.ts
+++ b/src/server/rest/service/ChargingStationService.ts
@@ -137,15 +137,15 @@ export default class ChargingStationService {
       chargingStation.chargingStationURL = filteredRequest.chargingStationURL;
     }
     // Update Power Max
-    if (Utils.hasOwnProperty(filteredRequest, 'maximumPower')) {
+    if (Utils.objectHasProperty(filteredRequest, 'maximumPower')) {
       chargingStation.maximumPower = filteredRequest.maximumPower;
     }
     // Update Current Type
-    if (Utils.hasOwnProperty(filteredRequest, 'currentType')) {
+    if (Utils.objectHasProperty(filteredRequest, 'currentType')) {
       chargingStation.currentType = filteredRequest.currentType;
     }
     // Update Cannot Charge in Parallel
-    if (Utils.hasOwnProperty(filteredRequest, 'cannotChargeInParallel')) {
+    if (Utils.objectHasProperty(filteredRequest, 'cannotChargeInParallel')) {
       chargingStation.cannotChargeInParallel = filteredRequest.cannotChargeInParallel;
     }
     // Update Site Area
@@ -156,7 +156,7 @@ export default class ChargingStationService {
       chargingStation.siteAreaID = null;
     }
     // Update Site Area
-    if (Utils.hasOwnProperty(filteredRequest, 'powerLimitUnit')) {
+    if (Utils.objectHasProperty(filteredRequest, 'powerLimitUnit')) {
       chargingStation.powerLimitUnit = filteredRequest.powerLimitUnit;
     }
     if (filteredRequest.coordinates && filteredRequest.coordinates.length === 2) {
@@ -940,7 +940,7 @@ export default class ChargingStationService {
         });
       }
       // Check if we have to load all connectors in case connector 0 fails
-      if (Utils.hasOwnProperty(req.body, 'loadAllConnectors')) {
+      if (Utils.objectHasProperty(req.body, 'loadAllConnectors')) {
         filteredRequest.loadAllConnectors = req.body.loadAllConnectors;
       }
       if (filteredRequest.loadAllConnectors && filteredRequest.args.connectorId === 0) {
@@ -1476,7 +1476,7 @@ export default class ChargingStationService {
       // Ok?
       if (result) {
         // OCPP Command with status
-        if (Utils.hasOwnProperty(result, 'status') && result.status !== OCPPStatus.ACCEPTED) {
+        if (Utils.objectHasProperty(result, 'status') && result.status !== OCPPStatus.ACCEPTED) {
           Logging.logError({
             tenantID: tenantID, source: chargingStation.id, user: user,
             module: 'ChargingStationService', method: 'handleChargingStationCommand',

--- a/src/server/rest/service/SiteService.ts
+++ b/src/server/rest/service/SiteService.ts
@@ -114,7 +114,7 @@ export default class SiteService {
         user: req.user
       });
     }
-    if (!filteredRequest.hasOwnProperty('siteAdmin')) {
+    if (!Utils.objectHasProperty(filteredRequest, 'siteAdmin')) {
       throw new AppError({
         source: Constants.CENTRAL_SERVER,
         errorCode: HTTPError.GENERAL_ERROR,
@@ -236,7 +236,7 @@ export default class SiteService {
         user: req.user
       });
     }
-    if (!filteredRequest.hasOwnProperty('siteOwner')) {
+    if (!Utils.objectHasProperty(filteredRequest, 'siteOwner')) {
       throw new AppError({
         source: Constants.CENTRAL_SERVER,
         errorCode: HTTPError.GENERAL_ERROR,

--- a/src/server/rest/service/UserService.ts
+++ b/src/server/rest/service/UserService.ts
@@ -458,12 +458,12 @@ export default class UserService {
         await UserStorage.saveUserRole(req.user.tenantID, user.id, filteredRequest.role);
       }
       // Save Admin Data
-      if (filteredRequest.plateID || filteredRequest.hasOwnProperty('notificationsActive')) {
+      if (filteredRequest.plateID || Utils.objectHasProperty(filteredRequest, 'notificationsActive')) {
         const adminData: { plateID?: string; notificationsActive?: boolean; notifications?: UserNotifications } = {};
         if (filteredRequest.plateID) {
           adminData.plateID = filteredRequest.plateID;
         }
-        if (filteredRequest.hasOwnProperty('notificationsActive')) {
+        if (Utils.objectHasProperty(filteredRequest, 'notificationsActive')) {
           adminData.notificationsActive = filteredRequest.notificationsActive;
           if (filteredRequest.notifications) {
             adminData.notifications = filteredRequest.notifications;
@@ -938,12 +938,12 @@ export default class UserService {
         await UserStorage.saveUserRole(req.user.tenantID, newUserID, filteredRequest.role);
       }
       // Save Admin Data
-      if (filteredRequest.plateID || filteredRequest.hasOwnProperty('notificationsActive')) {
+      if (filteredRequest.plateID || Utils.objectHasProperty(filteredRequest, 'notificationsActive')) {
         const adminData: { plateID?: string; notificationsActive?: boolean; notifications?: UserNotifications } = {};
         if (filteredRequest.plateID) {
           adminData.plateID = filteredRequest.plateID;
         }
-        if (filteredRequest.hasOwnProperty('notificationsActive')) {
+        if (Utils.objectHasProperty(filteredRequest, 'notificationsActive')) {
           adminData.notificationsActive = filteredRequest.notificationsActive;
           if (filteredRequest.notifications) {
             adminData.notifications = filteredRequest.notifications;

--- a/src/server/rest/service/security/ChargingStationSecurity.ts
+++ b/src/server/rest/service/security/ChargingStationSecurity.ts
@@ -197,22 +197,22 @@ export default class ChargingStationSecurity {
   public static filterChargingStationParamsUpdateRequest(request: any): Partial<ChargingStation> {
     const filteredRequest: any = {};
     filteredRequest.id = sanitize(request.id);
-    if (request.hasOwnProperty('chargingStationURL')) {
+    if (Utils.objectHasProperty(request, 'chargingStationURL')) {
       filteredRequest.chargingStationURL = sanitize(request.chargingStationURL);
     }
-    if (request.hasOwnProperty('maximumPower')) {
+    if (Utils.objectHasProperty(request, 'maximumPower')) {
       filteredRequest.maximumPower = sanitize(request.maximumPower);
     }
-    if (request.hasOwnProperty('cannotChargeInParallel')) {
+    if (Utils.objectHasProperty(request, 'cannotChargeInParallel')) {
       filteredRequest.cannotChargeInParallel = UtilsSecurity.filterBoolean(request.cannotChargeInParallel);
     }
-    if (request.hasOwnProperty('siteArea')) {
+    if (Utils.objectHasProperty(request, 'siteArea')) {
       filteredRequest.siteArea = sanitize(request.siteArea);
     }
-    if (request.hasOwnProperty('powerLimitUnit')) {
+    if (Utils.objectHasProperty(request, 'powerLimitUnit')) {
       filteredRequest.powerLimitUnit = sanitize(request.powerLimitUnit);
     }
-    if (request.hasOwnProperty('currentType')) {
+    if (Utils.objectHasProperty(request, 'currentType')) {
       filteredRequest.currentType = sanitize(request.currentType);
     }
     if (request.coordinates && request.coordinates.length === 2) {
@@ -244,13 +244,13 @@ export default class ChargingStationSecurity {
 
   public static filterChargingProfileUpdateRequest(request: any): ChargingProfile {
     const filteredRequest: ChargingProfile = {} as ChargingProfile;
-    if (request.hasOwnProperty('chargingStationID')) {
+    if (Utils.objectHasProperty(request, 'chargingStationID')) {
       filteredRequest.chargingStationID = sanitize(request.chargingStationID);
     }
-    if (request.hasOwnProperty('connectorID')) {
+    if (Utils.objectHasProperty(request, 'connectorID')) {
       filteredRequest.connectorID = sanitize(request.connectorID);
     }
-    if (request.hasOwnProperty('profile')) {
+    if (Utils.objectHasProperty(request, 'profile')) {
       filteredRequest.profile = ChargingStationSecurity.filterChargingProfile(request.profile);
     }
     return filteredRequest;
@@ -264,58 +264,58 @@ export default class ChargingStationSecurity {
     if (request.args) {
       filteredRequest.args = {};
       // Check
-      if (request.args.hasOwnProperty('type')) {
+      if (Utils.objectHasProperty(request.args, 'type')) {
         filteredRequest.args.type = sanitize(request.args.type);
       }
-      if (request.args.hasOwnProperty('key')) {
+      if (Utils.objectHasProperty(request.args, 'key')) {
         filteredRequest.args.key = sanitize(request.args.key);
       }
-      if (request.args.hasOwnProperty('value')) {
+      if (Utils.objectHasProperty(request.args, 'value')) {
         filteredRequest.args.value = sanitize(request.args.value);
       }
-      if (request.args.hasOwnProperty('connectorId')) {
+      if (Utils.objectHasProperty(request.args, 'connectorId')) {
         filteredRequest.args.connectorId = sanitize(request.args.connectorId);
       }
-      if (request.args.hasOwnProperty('duration')) {
+      if (Utils.objectHasProperty(request.args, 'duration')) {
         filteredRequest.args.duration = sanitize(request.args.duration);
       }
-      if (request.args.hasOwnProperty('chargingRateUnit')) {
+      if (Utils.objectHasProperty(request.args, 'chargingRateUnit')) {
         filteredRequest.args.chargingRateUnit = sanitize(request.args.chargingRateUnit);
       }
-      if (request.args.hasOwnProperty('chargingProfilePurpose')) {
+      if (Utils.objectHasProperty(request.args, 'chargingProfilePurpose')) {
         filteredRequest.args.chargingProfilePurpose = sanitize(request.args.chargingProfilePurpose);
       }
-      if (request.args.hasOwnProperty('stackLevel')) {
+      if (Utils.objectHasProperty(request.args, 'stackLevel')) {
         filteredRequest.args.stackLevel = sanitize(request.args.stackLevel);
       }
-      if (request.args.hasOwnProperty('tagID')) {
+      if (Utils.objectHasProperty(request.args, 'tagID')) {
         filteredRequest.args.tagID = sanitize(request.args.tagID);
       }
-      if (request.args.hasOwnProperty('location')) {
+      if (Utils.objectHasProperty(request.args, 'location')) {
         filteredRequest.args.location = sanitize(request.args.location);
       }
-      if (request.args.hasOwnProperty('retries')) {
+      if (Utils.objectHasProperty(request.args, 'retries')) {
         filteredRequest.args.retries = sanitize(request.args.retries);
       }
-      if (request.args.hasOwnProperty('retryInterval')) {
+      if (Utils.objectHasProperty(request.args, 'retryInterval')) {
         filteredRequest.args.retryInterval = sanitize(request.args.retryInterval);
       }
-      if (request.args.hasOwnProperty('startTime')) {
+      if (Utils.objectHasProperty(request.args, 'startTime')) {
         filteredRequest.args.startTime = sanitize(request.args.startTime);
       }
-      if (request.args.hasOwnProperty('stopTime')) {
+      if (Utils.objectHasProperty(request.args, 'stopTime')) {
         filteredRequest.args.stopTime = sanitize(request.args.stopTime);
       }
-      if (request.args.hasOwnProperty('retrieveDate')) {
+      if (Utils.objectHasProperty(request.args, 'retrieveDate')) {
         filteredRequest.args.retrieveDate = sanitize(request.args.retrieveDate);
       }
-      if (request.args.hasOwnProperty('retryInterval')) {
+      if (Utils.objectHasProperty(request.args, 'retryInterval')) {
         filteredRequest.args.retryInterval = sanitize(request.args.retryInterval);
       }
-      if (request.args.hasOwnProperty('transactionId')) {
+      if (Utils.objectHasProperty(request.args, 'transactionId')) {
         filteredRequest.args.transactionId = sanitize(request.args.transactionId);
       }
-      if (request.args.hasOwnProperty('csChargingProfiles')) {
+      if (Utils.objectHasProperty(request.args, 'csChargingProfiles')) {
         filteredRequest.args.csChargingProfiles = ChargingStationSecurity.filterChargingProfile(request.args.csChargingProfiles);
       }
     }
@@ -351,59 +351,59 @@ export default class ChargingStationSecurity {
   private static filterChargingProfile(request: any): Profile {
     const filteredRequest: Profile = {} as Profile;
     // Check
-    if (request.hasOwnProperty('chargingProfileId')) {
+    if (Utils.objectHasProperty(request, 'chargingProfileId')) {
       filteredRequest.chargingProfileId = sanitize(request.chargingProfileId);
     }
-    if (request.hasOwnProperty('transactionId')) {
+    if (Utils.objectHasProperty(request, 'transactionId')) {
       filteredRequest.transactionId = sanitize(request.transactionId);
     }
-    if (request.hasOwnProperty('stackLevel')) {
+    if (Utils.objectHasProperty(request, 'stackLevel')) {
       filteredRequest.stackLevel = sanitize(request.stackLevel);
     }
-    if (request.hasOwnProperty('chargingProfilePurpose')) {
+    if (Utils.objectHasProperty(request, 'chargingProfilePurpose')) {
       filteredRequest.chargingProfilePurpose = sanitize(request.chargingProfilePurpose);
     }
-    if (request.hasOwnProperty('chargingProfileKind')) {
+    if (Utils.objectHasProperty(request, 'chargingProfileKind')) {
       filteredRequest.chargingProfileKind = sanitize(request.chargingProfileKind);
     }
-    if (request.hasOwnProperty('recurrencyKind')) {
+    if (Utils.objectHasProperty(request, 'recurrencyKind')) {
       filteredRequest.recurrencyKind = sanitize(request.recurrencyKind);
     }
-    if (request.hasOwnProperty('validFrom')) {
+    if (Utils.objectHasProperty(request, 'validFrom')) {
       filteredRequest.validFrom = sanitize(request.validFrom);
     }
-    if (request.hasOwnProperty('validTo')) {
+    if (Utils.objectHasProperty(request, 'validTo')) {
       filteredRequest.validTo = sanitize(request.validTo);
     }
-    if (request.hasOwnProperty('chargingSchedule')) {
+    if (Utils.objectHasProperty(request, 'chargingSchedule')) {
       const chargingSchedule: ChargingSchedule = {} as ChargingSchedule;
       filteredRequest.chargingSchedule = chargingSchedule;
       // Check
-      if (request.chargingSchedule.hasOwnProperty('duration')) {
+      if (Utils.objectHasProperty(request.chargingSchedule, 'duration')) {
         chargingSchedule.duration = sanitize(request.chargingSchedule.duration);
       }
-      if (request.chargingSchedule.hasOwnProperty('startSchedule')) {
+      if (Utils.objectHasProperty(request.chargingSchedule, 'startSchedule')) {
         chargingSchedule.startSchedule = sanitize(request.chargingSchedule.startSchedule);
       }
-      if (request.chargingSchedule.hasOwnProperty('chargingRateUnit')) {
+      if (Utils.objectHasProperty(request.chargingSchedule, 'chargingRateUnit')) {
         chargingSchedule.chargingRateUnit = sanitize(request.chargingSchedule.chargingRateUnit);
       }
-      if (request.chargingSchedule.hasOwnProperty('minChargeRate')) {
+      if (Utils.objectHasProperty(request.chargingSchedule, 'minChargeRate')) {
         chargingSchedule.minChargeRate = sanitize(request.chargingSchedule.minChargeRate);
       }
-      if (request.chargingSchedule.hasOwnProperty('chargingSchedulePeriod')) {
+      if (Utils.objectHasProperty(request.chargingSchedule, 'chargingSchedulePeriod')) {
         filteredRequest.chargingSchedule.chargingSchedulePeriod = [];
         // Check
         for (const chargingSchedulePeriod of request.chargingSchedule.chargingSchedulePeriod) {
           const chargingSchedulePeriodNew: ChargingSchedulePeriod = {} as ChargingSchedulePeriod;
           // Check
-          if (chargingSchedulePeriod.hasOwnProperty('startPeriod')) {
+          if (Utils.objectHasProperty(chargingSchedulePeriod, 'startPeriod')) {
             chargingSchedulePeriodNew.startPeriod = sanitize(chargingSchedulePeriod.startPeriod);
           }
-          if (chargingSchedulePeriod.hasOwnProperty('limit')) {
+          if (Utils.objectHasProperty(chargingSchedulePeriod, 'limit')) {
             chargingSchedulePeriodNew.limit = sanitize(chargingSchedulePeriod.limit);
           }
-          if (chargingSchedulePeriod.hasOwnProperty('numberPhases')) {
+          if (Utils.objectHasProperty(chargingSchedulePeriod, 'numberPhases')) {
             chargingSchedulePeriodNew.numberPhases = sanitize(chargingSchedulePeriod.numberPhases);
           }
           // Add

--- a/src/server/rest/service/security/SiteAreaSecurity.ts
+++ b/src/server/rest/service/security/SiteAreaSecurity.ts
@@ -7,6 +7,7 @@ import SiteSecurity from './SiteSecurity';
 import UserToken from '../../../../types/UserToken';
 import UtilsSecurity from './UtilsSecurity';
 import { DataResult } from '../../../../types/DataResult';
+import Utils from "../../../../utils/Utils";
 
 export default class SiteAreaSecurity {
 
@@ -83,7 +84,7 @@ export default class SiteAreaSecurity {
         filteredSiteArea.siteID = siteArea.siteID;
         filteredSiteArea.maximumPower = siteArea.maximumPower;
       }
-      if (siteArea.hasOwnProperty('address')) {
+      if (Utils.objectHasProperty(siteArea, 'address')) {
         filteredSiteArea.address = UtilsSecurity.filterAddressRequest(siteArea.address);
       }
       if (siteArea.connectorStats) {
@@ -91,7 +92,7 @@ export default class SiteAreaSecurity {
         // TODO: To keep backward compat with Mobile App: remove it once new version is deployed
         filteredSiteArea = { ...filteredSiteArea, ...siteArea.connectorStats };
       }
-      if (siteArea.hasOwnProperty('accessControl')) {
+      if (Utils.objectHasProperty(siteArea, 'accessControl')) {
         filteredSiteArea.accessControl = siteArea.accessControl;
       }
       if (siteArea.site) {

--- a/src/server/rest/service/security/TransactionSecurity.ts
+++ b/src/server/rest/service/security/TransactionSecurity.ts
@@ -114,7 +114,7 @@ export default class TransactionSecurity {
       // Set only necessary info
       filteredTransaction = {} as Transaction;
       filteredTransaction.id = transaction.id;
-      if (transaction.hasOwnProperty('errorCode')) {
+      if (Utils.objectHasProperty(transaction, 'errorCode')) {
         filteredTransaction.uniqueId = transaction.uniqueId;
         (filteredTransaction as TransactionInError).errorCode = (transaction as TransactionInError).errorCode;
       }
@@ -125,7 +125,7 @@ export default class TransactionSecurity {
       filteredTransaction.meterStart = transaction.meterStart;
       filteredTransaction.timestamp = transaction.timestamp;
       filteredTransaction.timezone = transaction.timezone;
-      if (transaction.hasOwnProperty('price')) {
+      if (Utils.objectHasProperty(transaction, 'price')) {
         filteredTransaction.price = transaction.price;
         filteredTransaction.roundedPrice = transaction.roundedPrice;
         filteredTransaction.priceUnit = transaction.priceUnit;
@@ -273,7 +273,7 @@ export default class TransactionSecurity {
   public static filterConsumptionFromTransactionRequest(request: any): HttpConsumptionFromTransactionRequest {
     const filteredRequest: HttpConsumptionFromTransactionRequest = {} as HttpConsumptionFromTransactionRequest;
     // Set
-    if (request.hasOwnProperty('TransactionId')) {
+    if (Utils.objectHasProperty(request, 'TransactionId')) {
       filteredRequest.TransactionId = Utils.convertToInt(sanitize(request.TransactionId));
     }
     filteredRequest.StartDateTime = sanitize(request.StartDateTime);

--- a/src/server/rest/service/security/UserSecurity.ts
+++ b/src/server/rest/service/security/UserSecurity.ts
@@ -8,6 +8,7 @@ import UserToken from '../../../../types/UserToken';
 import UtilsSecurity from './UtilsSecurity';
 import sanitize from 'mongo-sanitize';
 import { UserInError } from '../../../../types/InError';
+import Utils from "../../../../utils/Utils";
 
 export default class UserSecurity {
 
@@ -108,7 +109,7 @@ export default class UserSecurity {
     if (request.email) {
       filteredRequest.email = sanitize(request.email);
     }
-    if (request.hasOwnProperty('notificationsActive')) {
+    if (Utils.objectHasProperty(request, 'notificationsActive')) {
       filteredRequest.notificationsActive = sanitize(request.notificationsActive);
     }
     if (request.notifications) {
@@ -169,7 +170,7 @@ export default class UserSecurity {
         filteredUser.tags = user.tags;
         filteredUser.plateID = user.plateID;
         filteredUser.role = user.role;
-        if (user.hasOwnProperty('errorCode')) {
+        if (Utils.objectHasProperty(user, 'errorCode')) {
           (filteredUser as UserInError).errorCode = (user as UserInError).errorCode;
         }
         if (user.address) {
@@ -193,7 +194,7 @@ export default class UserSecurity {
         filteredUser.tags = user.tags;
         filteredUser.plateID = user.plateID;
         filteredUser.role = user.role;
-        if (user.hasOwnProperty('errorCode')) {
+        if (Utils.objectHasProperty(user, 'errorCode')) {
           (filteredUser as UserInError).errorCode = (user as UserInError).errorCode;
         }
         if (user.address) {

--- a/src/server/rest/service/security/UtilsSecurity.ts
+++ b/src/server/rest/service/security/UtilsSecurity.ts
@@ -65,7 +65,7 @@ export default class UtilsSecurity {
     // Skip
     UtilsSecurity.filterSkip(request, filteredRequest);
     // Count Only?
-    if (request.hasOwnProperty('OnlyRecordCount')) {
+    if (Utils.objectHasProperty(request, 'OnlyRecordCount')) {
       filteredRequest.OnlyRecordCount = UtilsSecurity.filterBoolean(request.OnlyRecordCount);
     }
   }

--- a/src/storage/mongodb/UserStorage.ts
+++ b/src/storage/mongodb/UserStorage.ts
@@ -288,7 +288,7 @@ export default class UserStorage {
         sendBillingUserSynchronizationFailed: userToSave.notifications ? Utils.convertToBoolean(userToSave.notifications.sendBillingUserSynchronizationFailed) : false,
         sendSessionNotStarted: userToSave.notifications ? Utils.convertToBoolean(userToSave.notifications.sendSessionNotStarted) : false,
       },
-      deleted: userToSave.hasOwnProperty('deleted') ? userToSave.deleted : false
+      deleted: Utils.objectHasProperty(userToSave, 'deleted') ? userToSave.deleted : false
     };
     // Check Created/Last Changed By
     DatabaseUtils.addLastChangedCreatedProps(userMDB, userToSave);
@@ -434,7 +434,7 @@ export default class UserStorage {
     if (params.plateID) {
       updatedUserMDB.plateID = params.plateID;
     }
-    if (params.hasOwnProperty('notificationsActive')) {
+    if (Utils.objectHasProperty(params, 'notificationsActive')) {
       updatedUserMDB.notificationsActive = params.notificationsActive;
     }
     if (params.notifications) {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -72,7 +72,7 @@ export default class Utils {
     return InactivityStatus.ERROR;
   }
 
-  public static hasOwnProperty(object: object, key: string): boolean {
+  public static objectHasProperty(object: object, key: string): boolean {
     return Object.prototype.hasOwnProperty.call(object, key);
   }
 

--- a/test/api/contextProvider/BigBuilder.ts
+++ b/test/api/contextProvider/BigBuilder.ts
@@ -143,11 +143,11 @@ export default class ContextBuilder {
     if (tenantContextDef.componentSettings) {
       for (const component in Constants.COMPONENTS) {
         const componentName = Constants.COMPONENTS[component];
-        if (tenantContextDef.componentSettings.hasOwnProperty(componentName)) {
+        if (Utils.objectHasProperty(tenantContextDef.componentSettings, componentName)) {
           components[componentName] = {
             active: true
           };
-          if (tenantContextDef.componentSettings[componentName].hasOwnProperty('type')) {
+          if (Utils.objectHasProperty(tenantContextDef.componentSettings[componentName], 'type')) {
             components[componentName]['type'] = tenantContextDef.componentSettings[componentName].type;
           }
         }
@@ -279,7 +279,7 @@ export default class ContextBuilder {
     this.tenantsContexts.push(newTenantContext);
     newTenantContext.addUsers(userList);
     // Check if Organization is active
-    if (buildTenant.components && buildTenant.components.hasOwnProperty(Constants.COMPONENTS.ORGANIZATION) &&
+    if (buildTenant.components && Utils.objectHasProperty(buildTenant.components, Constants.COMPONENTS.ORGANIZATION) &&
       buildTenant.components[Constants.COMPONENTS.ORGANIZATION].active) {
       // Create the company
       for (let counterComp = 1; counterComp <= NBR_COMPANIES; counterComp++) {

--- a/test/api/contextProvider/ContextBuilder.ts
+++ b/test/api/contextProvider/ContextBuilder.ts
@@ -82,11 +82,11 @@ export default class ContextBuilder {
     if (tenantContextDef.componentSettings) {
       for (const component in Constants.COMPONENTS) {
         const componentName = Constants.COMPONENTS[component];
-        if (tenantContextDef.componentSettings.hasOwnProperty(componentName)) {
+        if (Utils.objectHasProperty(tenantContextDef.componentSettings, componentName)) {
           components[componentName] = {
             active: true
           };
-          if (tenantContextDef.componentSettings[componentName].hasOwnProperty('type')) {
+          if (Utils.objectHasProperty(tenantContextDef.componentSettings[componentName], 'type')) {
             components[componentName]['type'] = tenantContextDef.componentSettings[componentName].type;
           }
         }
@@ -197,7 +197,7 @@ export default class ContextBuilder {
     this.tenantsContexts.push(newTenantContext);
     newTenantContext.addUsers(userList);
     // Check if Organization is active
-    if (buildTenant.components && buildTenant.components.hasOwnProperty(Constants.COMPONENTS.ORGANIZATION) &&
+    if (buildTenant.components && Utils.objectHasProperty(buildTenant.components, Constants.COMPONENTS.ORGANIZATION) &&
       buildTenant.components[Constants.COMPONENTS.ORGANIZATION].active) {
       // Create the company
       for (const companyDef of CONTEXTS.TENANT_COMPANY_LIST) {

--- a/test/api/contextProvider/TenantContext.ts
+++ b/test/api/contextProvider/TenantContext.ts
@@ -11,6 +11,7 @@ import OCPPJsonService15 from '../ocpp/soap/OCPPSoapService15';
 import SiteAreaContext from './SiteAreaContext';
 import SiteContext from './SiteContext';
 import Tenant from '../../types/Tenant';
+import Utils from "../../../src/utils/Utils";
 
 export default class TenantContext {
 
@@ -152,7 +153,7 @@ export default class TenantContext {
       let conditionMet = null;
       for (const key in params) {
         const userContextDef = CONTEXTS.TENANT_USER_LIST.find((userList) => userList.id === user.id);
-        if (user.hasOwnProperty(key)) {
+        if (Utils.objectHasProperty(user, key)) {
           if (conditionMet !== null) {
             conditionMet = conditionMet && user[key] === params[key];
           } else {
@@ -187,10 +188,10 @@ export default class TenantContext {
    */
   addUsers(users) {
     for (const user of users) {
-      if (!user.hasOwnProperty('password')) {
+      if (!Utils.objectHasProperty(user, 'password')) {
         user.password = config.get('admin.password');
       }
-      if (!user.hasOwnProperty('centralServerService')) {
+      if (!Utils.objectHasProperty(user, 'centralServerService')) {
         user.centralServerService = new CentralServerService(this.tenant.subdomain, user);
       }
       this.context.users.push(user);
@@ -199,10 +200,10 @@ export default class TenantContext {
 
   async createUser(user = Factory.user.build(), loggedUser = null) {
     const createdUser = await this.centralAdminServerService.createEntity(this.centralAdminServerService.userApi, user);
-    if (!createdUser.hasOwnProperty('password')) {
+    if (!Utils.objectHasProperty(createdUser, 'password')) {
       createdUser.password = config.get('admin.password');
     }
-    if (!createdUser.hasOwnProperty('centralServerService')) {
+    if (!Utils.objectHasProperty(createdUser, 'centralServerService')) {
       createdUser.centralServerService = new CentralServerService(this.tenant.subdomain, createdUser);
     }
     this.context.createdUsers.push(createdUser);


### PR DESCRIPTION
I renamed the function to `objectHasProperty` because `hasOwnProperty` was still interpreted as an error by the Linter as a usage of built-in prototype on `Utils` instance.