### PR TITLE
Fix 404 return on firmware download.

### DIFF
--- a/src/server/rest/CentralRestServer.ts
+++ b/src/server/rest/CentralRestServer.ts
@@ -78,6 +78,7 @@ export default class CentralRestServer {
     this.express.all('/client%2Futil%2FFirmwareDownload%3FFileName%3Dr7_update_3.3.0.10_d4.epk', async (req: Request, res: Response, next: NextFunction) => {
       req.url = decodeURIComponent(req.originalUrl);
       req.params.action = 'FirmwareDownload';
+      req.query.FileName = 'r7_update_3.3.0.10_d4.epk';
       await CentralRestServerService.restServiceUtil(req, res, next);
     });
 


### PR DESCRIPTION
Yes, the full URL is given but I've not found a better way.

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>