### PR TITLE
Fix firmware download

### DIFF
--- a/src/assets/server/rest/v1/docs/e-mobility-oas.json
+++ b/src/assets/server/rest/v1/docs/e-mobility-oas.json
@@ -2875,7 +2875,7 @@
         "parameters": [
           {
             "in": "query",
-            "name": "fileName",
+            "name": "FileName",
             "description": "Firmware file name",
             "required": true,
             "schema": {

--- a/src/assets/server/rest/v1/docs/e-mobility-oas.json
+++ b/src/assets/server/rest/v1/docs/e-mobility-oas.json
@@ -2876,7 +2876,7 @@
           {
             "in": "query",
             "name": "FileName",
-            "description": "Firmware ID",
+            "description": "Firmware file name",
             "required": true,
             "schema": {
               "type": "string"

--- a/src/assets/server/rest/v1/docs/e-mobility-oas.json
+++ b/src/assets/server/rest/v1/docs/e-mobility-oas.json
@@ -2864,7 +2864,7 @@
         }
       }
     },
-    "/api/chargingstations/firmware/{id}": {
+    "/api/chargingstations/firmware/download": {
       "get": {
         "security": [
           {
@@ -2874,8 +2874,8 @@
         "description": "Get Charging Station firmware",
         "parameters": [
           {
-            "in": "path",
-            "name": "id",
+            "in": "query",
+            "name": "FileName",
             "description": "Firmware ID",
             "required": true,
             "schema": {

--- a/src/assets/server/rest/v1/docs/e-mobility-oas.json
+++ b/src/assets/server/rest/v1/docs/e-mobility-oas.json
@@ -2875,7 +2875,7 @@
         "parameters": [
           {
             "in": "query",
-            "name": "FileName",
+            "name": "fileName",
             "description": "Firmware file name",
             "required": true,
             "schema": {

--- a/src/server/rest/v1/service/ChargingStationService.ts
+++ b/src/server/rest/v1/service/ChargingStationService.ts
@@ -968,7 +968,7 @@ export default class ChargingStationService {
   public static async handleGetFirmware(action: ServerAction, req: Request, res: Response, next: NextFunction): Promise<void> {
     // Filter
     const filteredRequest = ChargingStationSecurity.filterChargingStationGetFirmwareRequest(req.query);
-    if (!filteredRequest.fileName) {
+    if (!filteredRequest.FileName) {
       throw new AppError({
         source: Constants.CENTRAL_SERVER,
         errorCode: HTTPError.GENERAL_ERROR,
@@ -978,10 +978,10 @@ export default class ChargingStationService {
       });
     }
     // Open a download stream and pipe it in the response
-    const bucketStream = ChargingStationStorage.getChargingStationFirmware(filteredRequest.fileName);
+    const bucketStream = ChargingStationStorage.getChargingStationFirmware(filteredRequest.FileName);
     // Set headers
     res.setHeader('Content-Type', 'application/octet-stream');
-    res.setHeader('Content-Disposition', 'attachment; filename=' + filteredRequest.fileName);
+    res.setHeader('Content-Disposition', 'attachment; filename=' + filteredRequest.FileName);
     // Write chunks
     bucketStream.on('data', (chunk) => {
       res.write(chunk);
@@ -991,7 +991,7 @@ export default class ChargingStationService {
       Logging.logError({
         tenantID: Constants.DEFAULT_TENANT,
         action: action,
-        message: `Firmware '${filteredRequest.fileName}' has not been found!`,
+        message: `Firmware '${filteredRequest.FileName}' has not been found!`,
         module: MODULE_NAME, method: 'handleGetFirmware',
         detailedMessages: { error: error.message, stack: error.stack },
       });
@@ -1006,7 +1006,7 @@ export default class ChargingStationService {
         Logging.logInfo({
           tenantID: Constants.DEFAULT_TENANT,
           action: action,
-          message: `Firmware '${filteredRequest.fileName}' has been downloaded with success`,
+          message: `Firmware '${filteredRequest.FileName}' has been downloaded with success`,
           module: MODULE_NAME, method: 'handleGetFirmware',
         });
         res.end();

--- a/src/server/rest/v1/service/ChargingStationService.ts
+++ b/src/server/rest/v1/service/ChargingStationService.ts
@@ -968,7 +968,7 @@ export default class ChargingStationService {
   public static async handleGetFirmware(action: ServerAction, req: Request, res: Response, next: NextFunction): Promise<void> {
     // Filter
     const filteredRequest = ChargingStationSecurity.filterChargingStationGetFirmwareRequest(req.query);
-    if (!filteredRequest.FileName) {
+    if (!filteredRequest.fileName) {
       throw new AppError({
         source: Constants.CENTRAL_SERVER,
         errorCode: HTTPError.GENERAL_ERROR,
@@ -978,10 +978,10 @@ export default class ChargingStationService {
       });
     }
     // Open a download stream and pipe it in the response
-    const bucketStream = ChargingStationStorage.getChargingStationFirmware(filteredRequest.FileName);
+    const bucketStream = ChargingStationStorage.getChargingStationFirmware(filteredRequest.fileName);
     // Set headers
     res.setHeader('Content-Type', 'application/octet-stream');
-    res.setHeader('Content-Disposition', 'attachment; filename=' + filteredRequest.FileName);
+    res.setHeader('Content-Disposition', 'attachment; filename=' + filteredRequest.fileName);
     // Write chunks
     bucketStream.on('data', (chunk) => {
       res.write(chunk);
@@ -991,7 +991,7 @@ export default class ChargingStationService {
       Logging.logError({
         tenantID: Constants.DEFAULT_TENANT,
         action: action,
-        message: `Firmware '${filteredRequest.FileName}' has not been found!`,
+        message: `Firmware '${filteredRequest.fileName}' has not been found!`,
         module: MODULE_NAME, method: 'handleGetFirmware',
         detailedMessages: { error: error.message, stack: error.stack },
       });
@@ -1006,7 +1006,7 @@ export default class ChargingStationService {
         Logging.logInfo({
           tenantID: Constants.DEFAULT_TENANT,
           action: action,
-          message: `Firmware '${filteredRequest.FileName}' has been downloaded with success`,
+          message: `Firmware '${filteredRequest.fileName}' has been downloaded with success`,
           module: MODULE_NAME, method: 'handleGetFirmware',
         });
         res.end();
@@ -1447,7 +1447,7 @@ export default class ChargingStationService {
           ChargingStationService.build3SizesPDFQrCode(pdfDocument, qrCodeImage, qrCodeTitle);
           // Add page (expect the last one)
           if (!connectorID && (chargingStations[chargingStations.length - 1] !== chargingStation ||
-            chargingStation.connectors[chargingStation.connectors.length - 1] !== connector)) {
+              chargingStation.connectors[chargingStation.connectors.length - 1] !== connector)) {
             pdfDocument.addPage();
           }
         }

--- a/src/server/rest/v1/service/ChargingStationService.ts
+++ b/src/server/rest/v1/service/ChargingStationService.ts
@@ -996,7 +996,7 @@ export default class ChargingStationService {
         detailedMessages: { error: error.message, stack: error.stack },
       });
       // Remove file related headers
-      res.setHeader('Content-Type', 'application/text');
+      res.setHeader('Content-Type', 'text/plain');
       res.setHeader('Content-Disposition', '');
       res.sendStatus(StatusCodes.NOT_FOUND);
     });

--- a/src/server/rest/v1/service/ChargingStationService.ts
+++ b/src/server/rest/v1/service/ChargingStationService.ts
@@ -995,17 +995,23 @@ export default class ChargingStationService {
         module: MODULE_NAME, method: 'handleGetFirmware',
         detailedMessages: { error: error.message, stack: error.stack },
       });
+      // Remove file related headers
+      res.setHeader('Content-Type', 'application/text');
+      res.setHeader('Content-Disposition', '');
       res.sendStatus(StatusCodes.NOT_FOUND);
     });
     // End of download
-    bucketStream.on('end', () => {
-      Logging.logInfo({
-        tenantID: Constants.DEFAULT_TENANT,
-        action: action,
-        message: `Firmware '${filteredRequest.FileName}' has been downloaded with success`,
-        module: MODULE_NAME, method: 'handleGetFirmware',
+    await new Promise((resolve) => {
+      bucketStream.on('end', () => {
+        Logging.logInfo({
+          tenantID: Constants.DEFAULT_TENANT,
+          action: action,
+          message: `Firmware '${filteredRequest.FileName}' has been downloaded with success`,
+          module: MODULE_NAME, method: 'handleGetFirmware',
+        });
+        res.end();
+        resolve();
       });
-      res.end();
     });
   }
 
@@ -1441,7 +1447,7 @@ export default class ChargingStationService {
           ChargingStationService.build3SizesPDFQrCode(pdfDocument, qrCodeImage, qrCodeTitle);
           // Add page (expect the last one)
           if (!connectorID && (chargingStations[chargingStations.length - 1] !== chargingStation ||
-              chargingStation.connectors[chargingStation.connectors.length - 1] !== connector)) {
+            chargingStation.connectors[chargingStation.connectors.length - 1] !== connector)) {
             pdfDocument.addPage();
           }
         }

--- a/src/server/rest/v1/service/ChargingStationService.ts
+++ b/src/server/rest/v1/service/ChargingStationService.ts
@@ -968,7 +968,7 @@ export default class ChargingStationService {
   public static async handleGetFirmware(action: ServerAction, req: Request, res: Response, next: NextFunction): Promise<void> {
     // Filter
     const filteredRequest = ChargingStationSecurity.filterChargingStationGetFirmwareRequest(req.query);
-    if (!filteredRequest.ID) {
+    if (!filteredRequest.FileName) {
       throw new AppError({
         source: Constants.CENTRAL_SERVER,
         errorCode: HTTPError.GENERAL_ERROR,
@@ -978,10 +978,10 @@ export default class ChargingStationService {
       });
     }
     // Open a download stream and pipe it in the response
-    const bucketStream = ChargingStationStorage.getChargingStationFirmware(filteredRequest.ID);
+    const bucketStream = ChargingStationStorage.getChargingStationFirmware(filteredRequest.FileName);
     // Set headers
     res.setHeader('Content-Type', 'application/octet-stream');
-    res.setHeader('Content-Disposition', 'attachment; filename=' + filteredRequest.ID);
+    res.setHeader('Content-Disposition', 'attachment; filename=' + filteredRequest.FileName);
     // Write chunks
     bucketStream.on('data', (chunk) => {
       res.write(chunk);
@@ -991,7 +991,7 @@ export default class ChargingStationService {
       Logging.logError({
         tenantID: Constants.DEFAULT_TENANT,
         action: action,
-        message: `Firmware '${filteredRequest.ID}' has not been found!`,
+        message: `Firmware '${filteredRequest.FileName}' has not been found!`,
         module: MODULE_NAME, method: 'handleGetFirmware',
         detailedMessages: { error: error.message, stack: error.stack },
       });
@@ -1002,7 +1002,7 @@ export default class ChargingStationService {
       Logging.logInfo({
         tenantID: Constants.DEFAULT_TENANT,
         action: action,
-        message: `Firmware '${filteredRequest.ID}' has been downloaded with success`,
+        message: `Firmware '${filteredRequest.FileName}' has been downloaded with success`,
         module: MODULE_NAME, method: 'handleGetFirmware',
       });
       res.end();

--- a/src/server/rest/v1/service/security/ChargingStationSecurity.ts
+++ b/src/server/rest/v1/service/security/ChargingStationSecurity.ts
@@ -281,7 +281,7 @@ export default class ChargingStationSecurity {
 
   public static filterChargingStationGetFirmwareRequest(request: any): HttpChargingStationGetFirmwareRequest {
     return {
-      FileName: sanitize(request.FileName),
+      fileName: sanitize(request.FileName),
     };
   }
 

--- a/src/server/rest/v1/service/security/ChargingStationSecurity.ts
+++ b/src/server/rest/v1/service/security/ChargingStationSecurity.ts
@@ -281,7 +281,7 @@ export default class ChargingStationSecurity {
 
   public static filterChargingStationGetFirmwareRequest(request: any): HttpChargingStationGetFirmwareRequest {
     return {
-      fileName: sanitize(request.fileName),
+      FileName: sanitize(request.FileName),
     };
   }
 

--- a/src/server/rest/v1/service/security/ChargingStationSecurity.ts
+++ b/src/server/rest/v1/service/security/ChargingStationSecurity.ts
@@ -281,7 +281,7 @@ export default class ChargingStationSecurity {
 
   public static filterChargingStationGetFirmwareRequest(request: any): HttpChargingStationGetFirmwareRequest {
     return {
-      fileName: sanitize(request.FileName),
+      fileName: sanitize(request.fileName),
     };
   }
 

--- a/src/server/rest/v1/service/security/ChargingStationSecurity.ts
+++ b/src/server/rest/v1/service/security/ChargingStationSecurity.ts
@@ -281,7 +281,7 @@ export default class ChargingStationSecurity {
 
   public static filterChargingStationGetFirmwareRequest(request: any): HttpChargingStationGetFirmwareRequest {
     return {
-      ID: sanitize(request.ID),
+      FileName: sanitize(request.FileName),
     };
   }
 

--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -417,7 +417,7 @@ export enum ServerRoute {
   REST_CHARGING_STATIONS_FIRMWARE_UPDATE = 'chargingstations/firmware/update',
   REST_CHARGING_STATIONS_CHANGE_AVAILABILITY = 'chargingstations/availability/change',
 
-  REST_CHARGING_STATIONS_DOWNLOAD_FIRMWARE = 'chargingstations/firmware/:id',
+  REST_CHARGING_STATIONS_DOWNLOAD_FIRMWARE = 'chargingstations/firmware/download',
   REST_CHARGING_STATIONS_QRCODE_GENERATE = 'chargingstations/:id/connectors/:connectorId/qrcode/generate',
   REST_CHARGING_STATIONS_QRCODE_DOWNLOAD = 'chargingstations/:id/connectors/:connectorId/qrcode/download',
 

--- a/src/types/requests/HttpChargingStationRequest.ts
+++ b/src/types/requests/HttpChargingStationRequest.ts
@@ -102,5 +102,5 @@ export interface HttpIsAuthorizedRequest {
 }
 
 export interface HttpChargingStationGetFirmwareRequest {
-  fileName: string;
+  FileName: string;
 }

--- a/src/types/requests/HttpChargingStationRequest.ts
+++ b/src/types/requests/HttpChargingStationRequest.ts
@@ -102,5 +102,5 @@ export interface HttpIsAuthorizedRequest {
 }
 
 export interface HttpChargingStationGetFirmwareRequest {
-  FileName: string;
+  fileName: string;
 }

--- a/src/types/requests/HttpChargingStationRequest.ts
+++ b/src/types/requests/HttpChargingStationRequest.ts
@@ -102,5 +102,5 @@ export interface HttpIsAuthorizedRequest {
 }
 
 export interface HttpChargingStationGetFirmwareRequest {
-  ID: string;
+  FileName: string;
 }


### PR DESCRIPTION
Two modifications :

1) Wrapped bucketStream `end` event in a Promise in order to avoid Express to send a 404 status (as the endpoint is full of callback, it seems that the default Express behavior is to send a 404 status)

2) Refactored endpoint route, because `/api/chargingstations/firmware/{filename}` could break with names containing a `/`.
