### PR TITLE
Billing #2183 - check STRIPE settings

### DIFF
--- a/src/integration/billing/BillingFactory.ts
+++ b/src/integration/billing/BillingFactory.ts
@@ -25,7 +25,10 @@ export default class BillingFactory {
         let billingIntegrationImpl = null;
         switch (settings.type) {
           case BillingSettingsType.STRIPE:
-            billingIntegrationImpl = new StripeBillingIntegration(tenantID, settings.stripe);
+            if (StripeBillingIntegration.checkSettingsConsistency(settings.stripe)) {
+              // Only call the constructor when the prerequisites are met
+              billingIntegrationImpl = new StripeBillingIntegration(tenantID, settings.stripe);
+            }
             break;
         }
         return billingIntegrationImpl;

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -34,6 +34,14 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
     this.axiosInstance = AxiosFactory.getAxiosInstance(this.tenantID);
   }
 
+  public static checkSettingsConsistency(settings: StripeBillingSetting): boolean {
+    if (settings.url && settings.secretKey && settings.publicKey) {
+      return true;
+    }
+    // STRIPE prerequisites are not met
+    return false ;
+  }
+
   public async getStripeInstance(): Promise<Stripe> {
     // TODO - To be removed - only used by automated tests!
     await this.checkConnection();


### PR DESCRIPTION
BillingFactory has been changed to avoid creating an instance of StripeBillingIntegration when the settings are not consistent.
The purpose of that change is to prevent that the STRIPE implementation gets called while the connection to the STRIPE account is not yet properly set.