### PR TITLE
Do not try to resend mail notification with error 450.

### DIFF
--- a/src/notification/email/EMailNotificationTask.ts
+++ b/src/notification/email/EMailNotificationTask.ts
@@ -253,6 +253,7 @@ export default class EMailNotificationTask implements NotificationTask {
         const err: SMTPError = error;
         switch (err.smtp) {
           // TODO: Add a fitting data structure to types to cope with SMTP returned codes
+          case 450:
           case 510:
           case 511:
             sendSmtpError = false;


### PR DESCRIPTION
The mailbox is unvailable or the SMTP server will retry by itself.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>