### PR TITLE
Fix vendorId length in OCPP-J status notification schema validation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ev-server",
-  "version": "2.3.6",
+  "version": "2.4.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/assets/server/ocpp/schemas/status-notification-request.json
+++ b/src/assets/server/ocpp/schemas/status-notification-request.json
@@ -61,7 +61,7 @@
             "type": "string",
             "description": "string defining the vendor identifier",
             "minLength": 0,
-            "maxLength": 25
+            "maxLength": 255
         },
         "vendorErrorCode": {
             "type": "string",


### PR DESCRIPTION
Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>