### PR TITLE
Stripe -  Synch User/Invoices Reorg

### DIFF
--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -182,7 +182,6 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
     } else {
       billingUser = await this.updateUser(user);
     }
-    await UserStorage.saveUserBillingData(this.tenantID, user.id, billingUser.billingData);
     return billingUser;
   }
 

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -162,7 +162,7 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
       // -------------------------------------------------------------------------------------------
       // Regular Situation - CustomerID is set and we trust it!
       // -------------------------------------------------------------------------------------------
-      exists = await this.userExists(user); // returns false when the customerID is not set
+      exists = await this.isUserSynchronized(user); // returns false when the customerID is not set
     } else {
       // -------------------------------------------------------------------------------------------
       // Specific use-case - Trying to REPAIR inconsistencies
@@ -292,7 +292,7 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
           source: Constants.CENTRAL_SERVER,
           action: ServerAction.BILLING_CHARGE_INVOICE,
           module: MODULE_NAME, method: 'chargeInvoices',
-          message: `Successfully charge invoice '${openInvoice.id}'`
+          message: `Successfully charged invoice '${openInvoice.id}'`
         });
         actionsDone.inSuccess++;
       } catch (error) {
@@ -479,7 +479,7 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
 
   abstract deleteUser(user: User): Promise<void>;
 
-  abstract userExists(user: User): Promise<boolean>;
+  abstract isUserSynchronized(user: User): Promise<boolean>;
 
   abstract getTaxes(): Promise<BillingTax[]>;
 
@@ -491,13 +491,11 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
 
   abstract downloadInvoiceDocument(invoice: BillingInvoice): Promise<BillingInvoiceDocument>;
 
-  // abstract finalizeInvoice(invoice: BillingInvoice): Promise<string>;
-
-  abstract setupPaymentMethod(user: User, paymentMethodId: string): Promise<BillingOperationResult>;
-
   abstract chargeInvoice(invoice: BillingInvoice): Promise<BillingInvoice>;
 
   abstract consumeBillingEvent(req: Request): Promise<boolean>;
+
+  abstract setupPaymentMethod(user: User, paymentMethodId: string): Promise<BillingOperationResult>;
 
   abstract getPaymentMethods(user: User): Promise<BillingPaymentMethodResult>;
 

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -109,7 +109,7 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
           continue;
         }
         // Get Billing User
-        const billingUser = await this.getBillingUserByInternalID(userBillingIDChangedInBilling);
+        const billingUser = await this.getUser(user);
         if (!billingUser) {
           // Only triggers an error if e-Mobility user is not deleted
           actionsDone.inError++;
@@ -637,8 +637,6 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
   abstract checkIfUserCanBeUpdated(user: User): Promise<boolean>;
 
   abstract checkIfUserCanBeDeleted(user: User): Promise<boolean>;
-
-  abstract getBillingUserByInternalID(id: string): Promise<BillingUser>;
 
   abstract getUsers(): Promise<BillingUser[]>;
 

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -259,7 +259,7 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
       for (const invoiceID of invoiceIDs) {
         try {
           // Let's replicate invoice data as a Billing Invoice
-          const billingInvoice = await this.synchronizeAsBillingInvoice(invoiceID);
+          const billingInvoice = await this.synchronizeAsBillingInvoice(invoiceID, true /* checkUserExists */);
           // Make sure we get the actual user - the one the invoice refers to
           const userInInvoice = await UserStorage.getUser(this.tenantID, billingInvoice.userID);
           // Update user billing data
@@ -511,7 +511,7 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
 
   abstract getUpdatedInvoiceIDsInBilling(billingUser?: BillingUser): Promise<string[]>;
 
-  abstract synchronizeAsBillingInvoice(stripeInvoiceID: string): Promise<BillingInvoice>;
+  abstract synchronizeAsBillingInvoice(stripeInvoiceID: string, checkUserExists: boolean): Promise<BillingInvoice>;
 
   abstract billInvoiceItem(user: User, billingInvoiceItems: BillingInvoiceItem, idemPotencyKey?: string): Promise<BillingInvoice>;
 

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -173,7 +173,6 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
       } catch (error) {
         // Let's create a new customer and get rid of the previous customerID
         exists = false;
-        user.billingData.customerID = null;
       }
     }
     // Create or Update the user and its billing data

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -733,24 +733,6 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
     };
   }
 
-  private async _isDeletedInStripe(customerID: string): Promise<boolean> {
-    try {
-      const customer = await this.stripe.customers.retrieve(
-        customerID
-      );
-      return customer.deleted ? customer.deleted : false;
-    } catch (error) {
-      // catch stripe errors and send the information back to the client
-      await Logging.logError({
-        tenantID: this.tenantID,
-        action: ServerAction.BILLING_SETUP_PAYMENT_METHOD,
-        module: MODULE_NAME, method: '_getPaymentMethods',
-        message: `Failed to check for deletion - customer '${customerID}'`,
-        detailedMessages: { error: error.message, stack: error.stack }
-      });
-    }
-  }
-
   public async startTransaction(transaction: Transaction): Promise<BillingDataTransactionStart> {
     // Check Stripe
     await this.checkConnection();

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -333,15 +333,8 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
     };
     // Let's persist the up-to-date data
     const freshInvoiceId = await BillingStorage.saveInvoice(this.tenantID, invoiceToSave);
+    // TODO - perf improvement? - can't we just reuse
     const freshBillingInvoice = await BillingStorage.getInvoice(this.tenantID, freshInvoiceId);
-    // --------------------------------------------------------------------------------------
-    // TODO - downloading the PDF is slow - it makes sense to postpone it!
-    // --------------------------------------------------------------------------------------
-    // if (!billingInvoice?.downloadable && freshBillingInvoice?.downloadable) {
-    //   // Perf optimization - download the PDF document (only when downloadable flag has changed)
-    //   const invoiceDocument = await this.downloadInvoiceDocument(freshBillingInvoice);
-    //   await BillingStorage.saveInvoiceDocument(this.tenantID, invoiceDocument);
-    // }
     return freshBillingInvoice;
   }
 
@@ -380,29 +373,6 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
       };
     }
   }
-
-  // No use-case so far - exposing it at the Billing Integration level is useless
-  // public async finalizeInvoice(invoice: BillingInvoice): Promise<string> {
-  //   await this.checkConnection();
-  //   try {
-  //     const stripeInvoice = await this.stripe.invoices.finalizeInvoice(invoice.invoiceID);
-  //     invoice.downloadUrl = stripeInvoice.invoice_pdf;
-  //     invoice.status = BillingInvoiceStatus.OPEN;
-  //     invoice.downloadable = true;
-  //     await BillingStorage.saveInvoice(this.tenantID, invoice);
-  //     const invoiceDocument = await this.downloadInvoiceDocument(invoice);
-  //     await BillingStorage.saveInvoiceDocument(this.tenantID, invoiceDocument);
-  //     return stripeInvoice.invoice_pdf;
-  //   } catch (error) {
-  //     throw new BackendError({
-  //       message: 'Failed to finalize invoice',
-  //       source: Constants.CENTRAL_SERVER,
-  //       module: MODULE_NAME,
-  //       method: 'finalizeInvoice',
-  //       action: ServerAction.BILLING_SEND_INVOICE
-  //     });
-  //   }
-  // }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   public async consumeBillingEvent(req: Request): Promise<boolean> {

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -211,37 +211,6 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
     return stripeInvoice;
   }
 
-  // TODO - name of the method is confusing - the returned value is a partial billing invoice (id is null)
-  public async getInvoice(id: string): Promise<BillingInvoice> {
-    // Check Stripe
-    await this.checkConnection();
-    // Get Invoice
-    try {
-      const stripeInvoice = await this.stripe.invoices.retrieve(id);
-      const { id: invoiceID, customer, number, amount_due: amount, amount_paid: amountPaid, status, currency, invoice_pdf: downloadUrl } = stripeInvoice;
-      const nbrOfItems: number = this.getNumberOfItems(stripeInvoice);
-      const customerID = customer as string;
-      const billingInvoice: BillingInvoice = {
-        id: null, // TODO - must be clarified - We cannot guess the Billing Invoice ID
-        invoiceID,
-        customerID,
-        number,
-        amount,
-        amountPaid,
-        status: status as BillingInvoiceStatus,
-        currency,
-        createdOn: new Date(stripeInvoice.created * 1000),
-        nbrOfItems: nbrOfItems,
-        downloadUrl,
-        downloadable: !!downloadUrl
-      };
-      return billingInvoice;
-    } catch (e) {
-      // TODO - This is suspicious
-      return null;
-    }
-  }
-
   private getNumberOfItems(stripeInvoice: Stripe.Invoice): number {
     // STRIPE version 8.137.0 - total_count property is deprecated - TODO - find another way to get it!
     const nbrOfItems: number = stripeInvoice.lines['total_count'];

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -793,6 +793,13 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
       }
     } else {
       // Not yet LIVE ... starting a transaction without a STRIPE CUSTOMER is allowed
+      await Logging.logWarning({
+        tenantID: this.tenantID,
+        source: Constants.CENTRAL_SERVER,
+        action: ServerAction.BILLING_TRANSACTION,
+        module: MODULE_NAME, method: 'startTransaction',
+        message: 'Live Mode is OFF - Start transaction might have been started with NO customer data'
+      });
     }
     return {
       cancelTransaction: false

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -277,10 +277,11 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
     // Let's create the STRIPE invoice
     const stripeInvoice: Stripe.Invoice = await this.stripe.invoices.create({
       customer: customerID,
-      collection_method: 'send_invoice', // TODO - must be clarified - other option is 'charge_automatically' ==> triggering an implicit payment!
-      days_until_due: 30, // TODO - must be clarified - get rid of this hardcoded default value
+      // collection_method: 'send_invoice', //Default option is 'charge_automatically'
+      // days_until_due: 30, // Optional when using default settings
       auto_advance: false, // our integration is responsible for transitioning the invoice between statuses
       metadata: {
+        tenantID: this.tenantID,
         userID
       }
     }, {

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -334,11 +334,14 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
     // Let's persist the up-to-date data
     const freshInvoiceId = await BillingStorage.saveInvoice(this.tenantID, invoiceToSave);
     const freshBillingInvoice = await BillingStorage.getInvoice(this.tenantID, freshInvoiceId);
-    if (!billingInvoice?.downloadable && freshBillingInvoice?.downloadable) {
-      // Perf optimization - download the PDF document (only when downloadable flag has changed)
-      const invoiceDocument = await this.downloadInvoiceDocument(freshBillingInvoice);
-      await BillingStorage.saveInvoiceDocument(this.tenantID, invoiceDocument);
-    }
+    // --------------------------------------------------------------------------------------
+    // TODO - downloading the PDF is slow - it makes sense to postpone it!
+    // --------------------------------------------------------------------------------------
+    // if (!billingInvoice?.downloadable && freshBillingInvoice?.downloadable) {
+    //   // Perf optimization - download the PDF document (only when downloadable flag has changed)
+    //   const invoiceDocument = await this.downloadInvoiceDocument(freshBillingInvoice);
+    //   await BillingStorage.saveInvoiceDocument(this.tenantID, invoiceDocument);
+    // }
     return freshBillingInvoice;
   }
 
@@ -360,7 +363,7 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
   }
 
   public async downloadInvoiceDocument(invoice: BillingInvoice): Promise<BillingInvoiceDocument> {
-    if (invoice.downloadUrl && invoice.downloadUrl !== '') {
+    if (invoice.downloadUrl) {
       // Get document
       const response = await this.axiosInstance.get(invoice.downloadUrl, {
         responseType: 'arraybuffer'

--- a/src/server/rest/v1/service/AuthService.ts
+++ b/src/server/rest/v1/service/AuthService.ts
@@ -546,8 +546,7 @@ export default class AuthService {
     const billingImpl = await BillingFactory.getBillingImpl(tenantID);
     if (billingImpl) {
       try {
-        const billingUser = await billingImpl.createUser(user);
-        await UserStorage.saveUserBillingData(tenantID, user.id, billingUser.billingData);
+        await billingImpl.createUser(user);
         Logging.logInfo({
           tenantID: tenantID,
           module: MODULE_NAME, method: 'handleVerifyEmail',

--- a/src/server/rest/v1/service/BillingService.ts
+++ b/src/server/rest/v1/service/BillingService.ts
@@ -595,11 +595,11 @@ export default class BillingService {
     // Filter
     const filteredRequest = BillingSecurity.filterDownloadInvoiceRequest(req.query);
     // Get the Invoice
-    const invoice = await BillingStorage.getInvoice(req.user.tenantID, filteredRequest.ID);
-    UtilsService.assertObjectExists(action, invoice, `Invoice ID '${filteredRequest.ID}' does not exist`,
+    const billingInvoice = await BillingStorage.getInvoice(req.user.tenantID, filteredRequest.ID);
+    UtilsService.assertObjectExists(action, billingInvoice, `Invoice ID '${filteredRequest.ID}' does not exist`,
       MODULE_NAME, 'handleDownloadInvoice', req.user);
     // Check Auth
-    if (!Authorizations.canDownloadInvoiceBilling(req.user, invoice.userID)) {
+    if (!Authorizations.canDownloadInvoiceBilling(req.user, billingInvoice.userID)) {
       throw new AppAuthError({
         errorCode: HTTPAuthError.FORBIDDEN,
         user: req.user,
@@ -619,14 +619,12 @@ export default class BillingService {
         user: req.user
       });
     }
-    // Get the Invoice Document
-    const invoiceDocument = await BillingStorage.getInvoiceDocument(req.user.tenantID, invoice.id);
-    UtilsService.assertObjectExists(action, invoiceDocument, `Invoice Document ID '${filteredRequest.ID}' does not exist`,
-      MODULE_NAME, 'handleDownloadInvoice', req.user);
+    // Get the PDF document directly from the Invoice
+    const invoiceDocument = await billingImpl.downloadInvoiceDocument(billingInvoice);
     // Send the Document
     if (invoiceDocument && invoiceDocument.content) {
       const base64RawData = invoiceDocument.content.split(`;${invoiceDocument.encoding},`).pop();
-      const filename = 'invoice_' + invoice.id + '.' + invoiceDocument.type;
+      const filename = 'invoice_' + billingInvoice.id + '.' + invoiceDocument.type;
       fs.writeFile(filename, base64RawData, { encoding: invoiceDocument.encoding }, (err) => {
         if (err) {
           console.error(err);
@@ -648,7 +646,7 @@ export default class BillingService {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
   public static async handleBillingChargeInvoice(action: ServerAction, req: Request, res: Response): Promise<void> {
 
     // TODO - no use-case for this endpoint so far! - only used for troubleshooting!

--- a/src/server/rest/v1/service/UserService.ts
+++ b/src/server/rest/v1/service/UserService.ts
@@ -513,8 +513,7 @@ export default class UserService {
       const billingImpl = await BillingFactory.getBillingImpl(req.user.tenantID);
       if (billingImpl) {
         try {
-          const billingUser = await billingImpl.updateUser(user);
-          await UserStorage.saveUserBillingData(req.user.tenantID, user.id, billingUser.billingData);
+          await billingImpl.updateUser(user);
         } catch (error) {
           await Logging.logError({
             tenantID: req.user.tenantID,
@@ -993,8 +992,7 @@ export default class UserService {
       if (billingImpl) {
         try {
           const user = await UserStorage.getUser(req.user.tenantID, newUser.id);
-          const billingUser = await billingImpl.createUser(user);
-          await UserStorage.saveUserBillingData(req.user.tenantID, user.id, billingUser.billingData);
+          await billingImpl.createUser(user);
           await Logging.logInfo({
             tenantID: req.user.tenantID,
             action: action,

--- a/src/storage/mongodb/BillingStorage.ts
+++ b/src/storage/mongodb/BillingStorage.ts
@@ -208,42 +208,6 @@ export default class BillingStorage {
     await Logging.traceEnd(tenantID, MODULE_NAME, 'savePaymentData', uniqueTimerID, updatedInvoiceMDB);
   }
 
-  public static async saveInvoiceDocument(tenantID: string, invoiceDocumentToSave: BillingInvoiceDocument): Promise<BillingInvoiceDocument> {
-    // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'saveInvoiceDocument');
-    // Build Request
-    // Properties to save
-    const invoiceDocumentMDB: any = {
-      _id: Utils.convertToObjectID(invoiceDocumentToSave.id),
-      type: invoiceDocumentToSave.type,
-      invoiceID: invoiceDocumentToSave.invoiceID,
-      encoding: invoiceDocumentToSave.encoding,
-      content: invoiceDocumentToSave.content
-    };
-    // Modify and return the modified document
-    await global.database.getCollection<BillingInvoiceDocument>(tenantID, 'invoicedocuments').findOneAndReplace(
-      { _id: invoiceDocumentMDB._id },
-      invoiceDocumentMDB,
-      { upsert: true }
-    );
-    // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'saveInvoiceDocument', uniqueTimerID, invoiceDocumentMDB);
-    return invoiceDocumentMDB._id.toHexString();
-  }
-
-  public static async getInvoiceDocument(tenantID: string, id: string): Promise<BillingInvoiceDocument> {
-    // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'getInvoiceDocument');
-    // Check Tenant
-    await DatabaseUtils.checkTenant(tenantID);
-    // Read DB
-    const invoiceDocumentMDB = await global.database.getCollection<BillingInvoiceDocument>(tenantID, 'invoicedocuments')
-      .findOne({ _id: Utils.convertToObjectID(id) });
-    // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'getInvoiceDocument', uniqueTimerID, invoiceDocumentMDB);
-    return invoiceDocumentMDB;
-  }
-
   public static async deleteInvoice(tenantID: string, id: string): Promise<void> {
     // Debug
     const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'deleteInvoice');
@@ -251,9 +215,6 @@ export default class BillingStorage {
     await DatabaseUtils.checkTenant(tenantID);
     // Delete the Invoice
     await global.database.getCollection<BillingInvoice>(tenantID, 'invoices')
-      .findOneAndDelete({ '_id': Utils.convertToObjectID(id) });
-    // Delete the Invoice Document
-    await global.database.getCollection<BillingInvoice>(tenantID, 'invoicedocuments')
       .findOneAndDelete({ '_id': Utils.convertToObjectID(id) });
     // Debug
     await Logging.traceEnd(tenantID, MODULE_NAME, 'deleteInvoice', uniqueTimerID, { id });
@@ -266,9 +227,6 @@ export default class BillingStorage {
     await DatabaseUtils.checkTenant(tenantID);
     // Delete the Invoice
     await global.database.getCollection<BillingInvoice>(tenantID, 'invoices')
-      .findOneAndDelete({ 'invoiceID': id });
-    // Delete the Invoice Document
-    await global.database.getCollection<BillingInvoice>(tenantID, 'invoicedocuments')
       .findOneAndDelete({ 'invoiceID': id });
     // Debug
     await Logging.traceEnd(tenantID, MODULE_NAME, 'deleteInvoice', uniqueTimerID, { id });

--- a/test/api/BillingStripeIntegrationTest.ts
+++ b/test/api/BillingStripeIntegrationTest.ts
@@ -37,12 +37,16 @@ describe('Billing Stripe Service', function() {
         // Anyway, there is no way to cleanup the utbilling stripe account!
       });
 
+      it('should create a DRAFT invoice and fail to pay', async () => {
+        await testData.checkBusinessProcessBillToPay(true);
+      });
+
       it('Should add a payment method to BILLING-TEST user', async () => {
         await testData.assignPaymentMethod('tok_visa');
       });
 
-      it('should create and pay a first invoice for BILLING-TEST user', async () => {
-        await testData.checkBusinessProcessBillToPay();
+      it('should create a DRAFT invoice and pay it for BILLING-TEST user', async () => {
+        await testData.checkBusinessProcessBillToPay(false, true);
       });
 
       it('Should download invoice as PDF', async () => {

--- a/test/api/BillingStripeIntegrationTest.ts
+++ b/test/api/BillingStripeIntegrationTest.ts
@@ -1,6 +1,9 @@
+import chai, { expect } from 'chai';
+
+import { BillingInvoiceStatus } from '../../src/types/Billing';
 import MongoDBStorage from '../../src/storage/mongodb/MongoDBStorage';
 import StripeIntegrationTestData from './BillingStripeTestData';
-import chai from 'chai';
+import TestConstants from './client/utils/TestConstants';
 import chaiSubset from 'chai-subset';
 import config from '../config';
 import global from '../../src/types/GlobalType';
@@ -42,6 +45,12 @@ describe('Billing Stripe Service', function() {
         await testData.checkBusinessProcessBillToPay();
       });
 
+      it('Should download invoice as PDF', async () => {
+        const response = await testData.adminUserService.billingApi.readAll({ Status: BillingInvoiceStatus.PAID }, TestConstants.DEFAULT_PAGING, TestConstants.DEFAULT_ORDERING, '/client/api/BillingUserInvoices');
+        expect(response.data.result.length).to.be.gt(0);
+        const downloadResponse = await testData.adminUserService.billingApi.downloadInvoiceDocument({ ID: response.data.result[0].id });
+        expect(downloadResponse.headers['content-type']).to.be.eq('application/pdf');
+      });
     });
 
     describe('immediate billing ON', () => {

--- a/test/api/BillingStripeTestData.ts
+++ b/test/api/BillingStripeTestData.ts
@@ -62,8 +62,8 @@ export default class StripeIntegrationTestData {
   public async forceBillingSettings(immediateBilling: boolean): Promise<void> {
     // The tests requires some settings to be forced
     this.billingImpl = await this.setBillingSystemValidCredentials(immediateBilling);
-    // Let's get access to the STRIPE implementation - StripeBillingIntegration instance
-    this.billingUser = await this.billingImpl.getBillingUserByInternalID(this.getCustomerID());
+    expect(this.billingImpl, 'Billing implementation should not ber null');
+    this.billingUser = await this.billingImpl.getUser(this.dynamicUser);
     expect(this.billingUser, 'Billing user should not ber null');
   }
 

--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -409,13 +409,6 @@ describe('Billing Service', function() {
         expect(response.data.result.length).to.be.eq(2);
       });
 
-      xit('Should download invoice as PDF', async () => {
-        const response = await testData.userService.billingApi.readAll({ Status: BillingInvoiceStatus.OPEN }, TestConstants.DEFAULT_PAGING, TestConstants.DEFAULT_ORDERING, '/client/api/BillingUserInvoices');
-        expect(response.data.result.length).to.be.gt(0);
-        const downloadResponse = await testData.userService.billingApi.downloadInvoiceDocument({ ID: response.data.result[0].id });
-        expect(downloadResponse.headers['content-type']).to.be.eq('application/pdf');
-      });
-
       it('should create an invoice after a transaction', async () => {
         const adminUser = testData.tenantContext.getUserContext(ContextDefinition.USER_CONTEXTS.DEFAULT_ADMIN);
         const basicUser = testData.tenantContext.getUserContext(ContextDefinition.USER_CONTEXTS.BASIC_USER);

--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -237,8 +237,8 @@ describe('Billing Service', function() {
         );
         testData.createdUsers.push(fakeUser);
         // Let's check that the corresponding billing user exists as well (a Customer in the STRIPE DB)
-        let exists = await testData.billingImpl.userExists(fakeUser);
-        expect(exists).to.be.true;
+        let billingUser = await testData.billingImpl.getUser(fakeUser);
+        expect(billingUser).to.be.not.null;
         // Let's update the new user
         fakeUser.firstName = 'Test';
         fakeUser.name = 'NAME';
@@ -249,7 +249,7 @@ describe('Billing Service', function() {
           false
         );
         // Let's check that the corresponding billing user was updated as well
-        const billingUser = await testData.billingImpl.getUser(fakeUser);
+        billingUser = await testData.billingImpl.getUser(fakeUser);
         expect(billingUser.name).to.be.eq(fakeUser.firstName + ' ' + fakeUser.name);
         // Let's delete the user
         await testData.userService.deleteEntity(
@@ -257,12 +257,10 @@ describe('Billing Service', function() {
           { id: testData.createdUsers[0].id }
         );
         // Verify that the corresponding billing user is gone
-        exists = await testData.billingImpl.userExists(testData.createdUsers[0]);
+        const exists = await testData.billingImpl.isUserSynchronized(testData.createdUsers[0]);
         expect(exists).to.be.false;
         testData.createdUsers.shift();
-
       });
-
 
       it('should add an item to the existing invoice after a transaction', async () => {
         await testData.userService.billingApi.forceSynchronizeUser({ id: testData.userContext.id });
@@ -481,7 +479,7 @@ describe('Billing Service', function() {
         testData.createdUsers.push(fakeUser);
         testData.billingImpl = await testData.setBillingSystemValidCredentials();
         await testData.userService.billingApi.synchronizeUser({ id: fakeUser.id });
-        const userExists = await testData.billingImpl.userExists(fakeUser);
+        const userExists = await testData.billingImpl.isUserSynchronized(fakeUser);
         expect(userExists).to.be.true;
       });
     });

--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -274,7 +274,8 @@ describe('Billing Service', function() {
         expect(itemsAfter).to.be.eq(itemsBefore + 1);
       });
 
-      it('should synchronize 1 invoice after a transaction', async () => {
+      xit('should synchronize 1 invoice after a transaction', async () => {
+        // TODO - Synchronize Invoices is for now disabled - c.f.: __liveMode!
         await testData.userService.billingApi.synchronizeInvoices({});
         const transactionID = await testData.generateTransaction(testData.userContext);
         expect(transactionID).to.not.be.null;


### PR DESCRIPTION
Checking LIVE MODE flag to switch off some features while we are still in beta mode.

- The purpose is to make it easier to test the payment flow on SLF without any impct on regular users 
- The user synchronization logic as been simplified to avoid some ping-pong between eMobility ad STRIPE.
- Still need to review  the invoice synchronization logic - current implementation is slow and most of the time not necessary anymore
- Includes as well some additional checks to make sure customerID is properly set and  consistent
- Deletion of users on the STRIPE side is not supported anymore! - will be done later