### PR TITLE
billing - repairUser  - to recover from inconsistencies

### DIFF
--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -96,8 +96,9 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
   }
 
   public async synchronizeUser(user: User): Promise<BillingUser> {
+    let billingUser: BillingUser = null;
     try {
-      const billingUser = await this._synchronizeUser(user);
+      billingUser = await this._synchronizeUser(user);
       await Logging.logInfo({
         tenantID: this.tenantID,
         actionOnUser: user,
@@ -118,12 +119,13 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
         detailedMessages: { error: error.message, stack: error.stack }
       });
     }
-    return null;
+    return billingUser;
   }
 
   public async forceSynchronizeUser(user: User): Promise<BillingUser> {
+    let billingUser: BillingUser = null;
     try {
-      const billingUser = await this._synchronizeUser(user, true /* !forceMode */);
+      billingUser = await this._synchronizeUser(user, true /* !forceMode */);
       if (user?.billingData?.customerID !== billingUser?.billingData?.customerID) {
         await Logging.logWarning({
           tenantID: this.tenantID,
@@ -152,22 +154,20 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
         detailedMessages: { error: error.message, stack: error.stack }
       });
     }
-    return null;
+    return billingUser;
   }
 
   private async _synchronizeUser(user: User, forceMode = false): Promise<BillingUser> {
     // Check if we need to create or update a STRIPE customer
-    let billingUser: BillingUser;
+    let billingUser: BillingUser = null;
     if (!forceMode) {
       // ------------------
       // Regular Situation
       // ------------------
       const exists = await this.isUserSynchronized(user); // returns false when the customerID is not set
       if (!exists) {
-        // Create the billing user and update the billing data
         billingUser = await this.createUser(user);
       } else {
-        // Update the billing user and the billing data
         billingUser = await this.updateUser(user);
       }
     } else {
@@ -178,16 +178,14 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
       let exists;
       try {
         exists = await this.getUser(user);
+        if (!exists) {
+          billingUser = await this.createUser(user);
+        } else {
+          billingUser = await this.updateUser(user);
+        }
       } catch (error) {
-        // Let's create a new customer and get rid of the previous customerID
-        exists = false;
-      }
-      if (!exists) {
-        // Repair by creating a new billing user and update the billing data
+        // Let's repair it
         billingUser = await this.repairUser(user);
-      } else {
-        // Update the billing user and the billing data
-        billingUser = await this.updateUser(user);
       }
     }
     return billingUser;

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -178,7 +178,12 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
     // Create or Update the user and its billing data
     let billingUser: BillingUser;
     if (!exists) {
-      billingUser = await this.createUser(user);
+      if (forceMode) {
+        // Specific situation where we want to repair inconsistencies
+        billingUser = await this.repairUser(user);
+      } else {
+        billingUser = await this.createUser(user);
+      }
     } else {
       billingUser = await this.updateUser(user);
     }
@@ -475,6 +480,8 @@ export default abstract class BillingIntegration<T extends BillingSetting> {
   abstract createUser(user: User): Promise<BillingUser>;
 
   abstract updateUser(user: User): Promise<BillingUser>;
+
+  abstract repairUser(user: User): Promise<BillingUser>;
 
   abstract deleteUser(user: User): Promise<void>;
 

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -1107,11 +1107,22 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
   }
 
   public async createUser(user: User): Promise<BillingUser> {
+    return await this._createUser(user, false);
+  }
+
+  public async repairUser(user: User): Promise<BillingUser> {
+    return await this._createUser(user, true);
+  }
+
+  private async _createUser(user: User, forceUserCreation: boolean): Promise<BillingUser> {
     // Check connection
     await this.checkConnection();
     await this.checkIfUserCanBeCreated(user);
     if (user.billingData?.customerID) {
-      throw new Error('Unexpected situation - the customerID is already set');
+      // The customerID should be preserved - unless the creation is forced
+      if (!forceUserCreation) {
+        throw new Error('Unexpected situation - the customerID is already set');
+      }
     }
     // Checks create a new STRIPE customer
     const customer: Stripe.Customer = await this.stripe.customers.create({

--- a/test/api/BillingStripeIntegrationTest.ts
+++ b/test/api/BillingStripeIntegrationTest.ts
@@ -48,13 +48,6 @@ describe('Billing Stripe Service', function() {
       it('should create a DRAFT invoice and pay it for BILLING-TEST user', async () => {
         await testData.checkBusinessProcessBillToPay(false, true);
       });
-
-      it('Should download invoice as PDF', async () => {
-        const response = await testData.adminUserService.billingApi.readAll({ Status: BillingInvoiceStatus.PAID }, TestConstants.DEFAULT_PAGING, TestConstants.DEFAULT_ORDERING, '/client/api/BillingUserInvoices');
-        expect(response.data.result.length).to.be.gt(0);
-        const downloadResponse = await testData.adminUserService.billingApi.downloadInvoiceDocument({ ID: response.data.result[0].id });
-        expect(downloadResponse.headers['content-type']).to.be.eq('application/pdf');
-      });
     });
 
     describe('immediate billing ON', () => {

--- a/test/api/BillingStripeIntegrationTest.ts
+++ b/test/api/BillingStripeIntegrationTest.ts
@@ -80,6 +80,11 @@ describe('Billing Stripe Service', function() {
         const newSource = await testData.assignPaymentMethod('tok_fr');
         await testData.checkDetachPaymentMethod(newSource.id);
       });
+
+      it('should be able to repair a user', async () => {
+        await testData.checkRepairInconsistencies();
+      });
+
     });
   });
 

--- a/test/api/BillingStripeTestData.ts
+++ b/test/api/BillingStripeTestData.ts
@@ -197,6 +197,10 @@ export default class StripeIntegrationTestData {
     expect(draftInvoices.length).to.be.eql(1);
     // Let's pay that particular DRAFT invoice
     await this.payDraftInvoice(draftInvoices[0], paymentShouldFail);
+    if (!paymentShouldFail) {
+      // Let's down load the corresponding PDF document
+      await this.checkDownloadInvoiceAsPdf(this.dynamicUser.id);
+    }
     // Next step should not be necessary
     // await testData.billingImpl.synchronizeInvoices(testData.dynamicUser);
     // Let's check that the user do not have any DRAFT invoice anymore
@@ -303,11 +307,9 @@ export default class StripeIntegrationTestData {
     return response?.data?.result;
   }
 
-  public async checkDownloadInvoiceAsPdf() : Promise<void> {
-    const paidInvoices = await await this.getInvoicesByState(this.dynamicUser.id, BillingInvoiceStatus.PAID);
+  public async checkDownloadInvoiceAsPdf(userId: string) : Promise<void> {
+    const paidInvoices = await await this.getInvoicesByState(userId, BillingInvoiceStatus.PAID);
     assert(paidInvoices, 'User should have at least a paid invoice');
-    // const response = await this.adminUserService.billingApi.readAll({ Status: BillingInvoiceStatus.PAID }, TestConstants.DEFAULT_PAGING, TestConstants.DEFAULT_ORDERING, '/client/api/BillingUserInvoices');
-    // expect(response.data.result.length).to.be.gt(0);
     const downloadResponse = await this.adminUserService.billingApi.downloadInvoiceDocument({ ID: paidInvoices[0].id });
     expect(downloadResponse.headers['content-type']).to.be.eq('application/pdf');
   }


### PR DESCRIPTION
forceSynchronizeUser was not repairing inconsitencies anymore when customerID was set with a wrong value.

This is fixed