### PR TITLE
Stripe - Billing Error Handling

### DIFF
--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -479,7 +479,7 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
       };
     } catch (error) {
       return {
-        succeeded: true,
+        succeeded: false,
         error,
       };
     }

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -10,13 +10,14 @@ import BillingStorage from '../../../storage/mongodb/BillingStorage';
 import Constants from '../../../utils/Constants';
 import Cypher from '../../../utils/Cypher';
 import { DataResult } from '../../../types/DataResult';
-import Decimal from 'decimal.js';
+import { Decimal } from 'decimal.js';
 import I18nManager from '../../../utils/I18nManager';
 import Logging from '../../../utils/Logging';
 import { Request } from 'express';
 import { ServerAction } from '../../../types/Server';
 import Stripe from 'stripe';
 import { StripeBillingSetting } from '../../../types/Setting';
+import StripeHelpers from './StripeHelpers';
 import Transaction from '../../../types/Transaction';
 import User from '../../../types/User';
 import UserStorage from '../../../storage/mongodb/UserStorage';
@@ -438,62 +439,50 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
 
   public async chargeInvoice(billingInvoice: BillingInvoice): Promise<BillingInvoice> {
     await this.checkConnection();
-    const billingOperationResult: BillingOperationResult = await this._chargeStripeInvoice(billingInvoice.invoiceID);
-    billingInvoice = await this.synchronizeAsBillingInvoice(billingInvoice.invoiceID, false);
-    if (!billingOperationResult.succeeded) {
-      // TODO - how to determine the root cause of the error
-      // c.f.: https://stripe.com/docs/error-codes#missing
-      await BillingStorage.saveLastPaymentFailure(this.tenantID, billingInvoice.id, billingOperationResult);
+    const operationResult: BillingOperationResult = await this._chargeStripeInvoice(billingInvoice.invoiceID);
+    if (!operationResult?.succeeded && operationResult?.error) {
+      await Logging.logError({
+        tenantID: this.tenantID,
+        source: Constants.CENTRAL_SERVER,
+        action: ServerAction.BILLING_TRANSACTION,
+        module: MODULE_NAME, method: 'billInvoiceItem',
+        message: `Payment attempt failed - stripe invoice: '${billingInvoice.invoiceID}'`,
+        detailedMessages: { error: operationResult.error.message, stack: operationResult.error.stack }
+      });
     }
+
+    billingInvoice = await this.synchronizeAsBillingInvoice(billingInvoice.invoiceID, false);
+    await StripeHelpers.handleStripeOperationResult(this.tenantID, billingInvoice, operationResult);
     return billingInvoice;
   }
 
   private async _chargeStripeInvoice(invoiceID: string): Promise<BillingOperationResult> {
-    // Fetch the invoice from stripe (do NOT TRUST the local copy)
-    let stripeInvoice: Stripe.Invoice = await this.stripe.invoices.retrieve(invoiceID);
-    // Check the current invoice status
-    if (stripeInvoice.status !== 'paid') {
-      // Finalize the invoice (if necessary)
-      if (stripeInvoice.status === 'draft') {
-        stripeInvoice = await this.stripe.invoices.finalizeInvoice(invoiceID);
-      }
-      // Once finalized, the invoice is in the "open" state!
-      if (stripeInvoice.status === 'open') {
-        // Set the payment options
-        const paymentOptions: Stripe.InvoicePayParams = {};
-        try {
+    try {
+      // Fetch the invoice from stripe (do NOT TRUST the local copy)
+      let stripeInvoice: Stripe.Invoice = await this.stripe.invoices.retrieve(invoiceID);
+      // Check the current invoice status
+      if (stripeInvoice.status !== 'paid') {
+        // Finalize the invoice (if necessary)
+        if (stripeInvoice.status === 'draft') {
+          stripeInvoice = await this.stripe.invoices.finalizeInvoice(invoiceID);
+        }
+        // Once finalized, the invoice is in the "open" state!
+        if (stripeInvoice.status === 'open') {
+          // Set the payment options
+          const paymentOptions: Stripe.InvoicePayParams = {};
           stripeInvoice = await this.stripe.invoices.pay(invoiceID, paymentOptions);
-        } catch (error) {
-          return this.shrinkStripeFailure(error);
         }
       }
+      return {
+        succeeded: true,
+        internalData: stripeInvoice
+      };
+    } catch (error) {
+      return {
+        succeeded: true,
+        error,
+      };
     }
-    return {
-      succeeded: true,
-      internalData: stripeInvoice
-    };
-  }
-
-  private shrinkStripeFailure(error): BillingOperationResult {
-    // Let's extract the data that we might be interested in
-    const { type, rawType, message, code, decline_code, payment_intent, payment_method, payment_method_type } = error;
-    // Wrap it in a format that we can consume!
-    const billingOperationResult: BillingOperationResult = {
-      succeeded: false,
-      error: {
-        message,
-        context: {
-          type,
-          rawType,
-          code,
-          declineCode: decline_code,
-          paymentIntentID: payment_intent?.id,
-          paymentMethodID: payment_method?.id,
-          paymentMethodType: payment_method_type
-        }
-      }
-    };
-    return billingOperationResult;
   }
 
   public async setupPaymentMethod(user: User, paymentMethodId: string): Promise<BillingOperationResult> {
@@ -587,13 +576,10 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
         module: MODULE_NAME, method: '_createSetupIntent',
         message: `Stripe operation failed - ${error?.message as string}`
       });
-      const billingOperationResult: BillingOperationResult = {
+      return {
         succeeded: false,
-        error: {
-          message: error?.message
-        }
+        error
       };
-      return billingOperationResult;
     }
   }
 
@@ -626,22 +612,19 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
         succeeded: true,
         internalData: paymentMethod
       };
-    } catch (e) {
+    } catch (error) {
       // catch stripe errors and send the information back to the client
       await Logging.logError({
         tenantID: this.tenantID,
         action: ServerAction.BILLING_SETUP_PAYMENT_METHOD,
         actionOnUser: user,
         module: MODULE_NAME, method: '_attachPaymentMethod',
-        message: `Stripe operation failed - ${e?.message as string}`
+        message: `Stripe operation failed - ${error?.message as string}`
       });
-      const billingOperationResult: BillingOperationResult = {
+      return {
         succeeded: false,
-        error: {
-          message: e?.message
-        }
+        error
       };
-      return billingOperationResult;
     }
   }
 
@@ -964,29 +947,26 @@ export default class StripeBillingIntegration extends BillingIntegration<StripeB
       // Let's create a new draft invoice (if none has been found)
       stripeInvoice = await this._createStripeInvoice(customerID, userID, this.buildIdemPotencyKey(idemPotencyKey));
     }
-    let paymentOperationResult: BillingOperationResult;
+    let operationResult: BillingOperationResult;
     if (this.settings.immediateBillingAllowed) {
       // Let's try to bill the stripe invoice using the default payment method of the customer
-      try {
-        paymentOperationResult = await this._chargeStripeInvoice(stripeInvoice.id);
-      } catch (error) {
+      operationResult = await this._chargeStripeInvoice(stripeInvoice.id);
+      if (!operationResult?.succeeded && operationResult?.error) {
         await Logging.logError({
           tenantID: this.tenantID,
           user: user.id,
           source: Constants.CENTRAL_SERVER,
           action: ServerAction.BILLING_TRANSACTION,
           module: MODULE_NAME, method: 'billInvoiceItem',
-          message: `Payment attempt failed - stripe invoice: '${stripeInvoice?.id }'`,
-          detailedMessages: { error: error.message, stack: error.stack }
+          message: `Payment attempt failed - stripe invoice: '${stripeInvoice?.id}'`,
+          detailedMessages: { error: operationResult.error.message, stack: operationResult.error.stack }
         });
       }
     }
     // Let's replicate some information on our side
     const billingInvoice = await this.synchronizeAsBillingInvoice(stripeInvoice.id, false);
-    // We have now a Billing Invoice - Let's update it with details about the last payment failure (if any)
-    if (!paymentOperationResult?.succeeded && paymentOperationResult?.error) {
-      await BillingStorage.saveLastPaymentFailure(this.tenantID, billingInvoice.id, paymentOperationResult.error);
-    }
+    // We have now a Billing Invoice - Let's update it with details about the last operation result
+    await StripeHelpers.handleStripeOperationResult(this.tenantID, billingInvoice, operationResult);
     // Return the billing invoice
     return billingInvoice;
   }

--- a/src/integration/billing/stripe/StripeHelpers.ts
+++ b/src/integration/billing/stripe/StripeHelpers.ts
@@ -1,0 +1,47 @@
+import { BillingInvoice, BillingOperationResult } from '../../../types/Billing';
+
+import BillingStorage from '../../../storage/mongodb/BillingStorage';
+import Stripe from 'stripe';
+
+export interface BillingError {
+  message: string
+  statusCode: number,
+  context?: unknown; // e.g.: payment ==> last_payment_error
+}
+
+export default class StripeHelpers {
+
+  public static async handleStripeOperationResult(tenantID: string, billingInvoice: BillingInvoice, operationResult: BillingOperationResult): Promise<void> {
+    if (!billingInvoice || !operationResult) {
+      return;
+    }
+    if (!operationResult.succeeded) {
+      // The last operation failed
+      const error = operationResult.error;
+      if (error instanceof Stripe.errors.StripeCardError) {
+        // The attempt to pay the invoice failed
+        const billingError: BillingError = StripeHelpers.shrinkStripeError(error);
+        await BillingStorage.saveLastPaymentFailure(tenantID, billingInvoice.id, billingError);
+      }
+    }
+  }
+
+  public static shrinkStripeError(error: Stripe.StripeCardError): BillingError {
+    // Let's extract the data that we might be interested in
+    const { statusCode, type, rawType, message, code, decline_code, payment_intent, payment_method, payment_method_type } = error ;
+    // Wrap it in a format that we can consume!
+    return {
+      message,
+      statusCode, // c.f.: https://stripe.com/docs/api/errors
+      context: {
+        type,
+        rawType,
+        code,
+        declineCode: decline_code,
+        paymentIntentID: payment_intent?.id,
+        paymentMethodID: payment_method?.id,
+        paymentMethodType: payment_method_type
+      }
+    };
+  }
+}

--- a/src/integration/billing/stripe/StripeHelpers.ts
+++ b/src/integration/billing/stripe/StripeHelpers.ts
@@ -1,41 +1,97 @@
-import { BillingError, BillingInvoice, BillingOperationResult } from '../../../types/Billing';
+import { BillingError, BillingErrorCode, BillingErrorType, BillingInvoice, BillingOperationResult } from '../../../types/Billing';
 
 import BillingStorage from '../../../storage/mongodb/BillingStorage';
 import Stripe from 'stripe';
 
 export default class StripeHelpers {
-
   public static async handleStripeOperationResult(tenantID: string, billingInvoice: BillingInvoice, operationResult: BillingOperationResult): Promise<void> {
     if (!billingInvoice || !operationResult) {
       return;
     }
     if (!operationResult.succeeded) {
-      // The last operation failed
-      const error = operationResult.error;
-      if (error instanceof Stripe.errors.StripeCardError) {
-        // The attempt to pay the invoice failed
-        const billingError: BillingError = StripeHelpers.shrinkStripeError(error);
-        await BillingStorage.saveLastPaymentFailure(tenantID, billingInvoice.id, billingError);
-      }
+      // The operation failed
+      const billingError: BillingError = StripeHelpers.convertToBillingError(operationResult.error);
+      await BillingStorage.saveLastBillingError(tenantID, billingInvoice.id, billingError);
     }
   }
 
-  public static shrinkStripeError(error: Stripe.StripeCardError): BillingError {
+  public static convertToBillingError(error: Error): BillingError {
     // Let's extract the data that we might be interested in
-    const { statusCode, type, rawType, message, code, decline_code, payment_intent, payment_method, payment_method_type } = error ;
+    const { errorCode, errorType } = StripeHelpers.guessRootCause(error);
+    const rootCause = StripeHelpers.shrinkRootCause(error);
     // Wrap it in a format that we can consume!
     return {
-      message,
-      statusCode, // c.f.: https://stripe.com/docs/api/errors
-      context: {
-        type,
-        rawType,
-        code,
-        declineCode: decline_code,
-        paymentIntentID: payment_intent?.id,
-        paymentMethodID: payment_method?.id,
-        paymentMethodType: payment_method_type
-      }
+      message: error.message,
+      errorType,
+      errorCode,
+      rootCause,
     };
+  }
+
+  public static guessRootCause(error: Error): { errorType: BillingErrorType, errorCode:BillingErrorCode } {
+    if (error instanceof Stripe.errors.StripeError) {
+      return StripeHelpers.guessStripeRootCause(error);
+    }
+    // Well this is not a STRIPE error
+    return {
+      errorType: BillingErrorType.APPLICATION_ERROR,
+      errorCode: BillingErrorCode.UNKNOWN_ERROR
+    };
+  }
+
+  public static guessStripeRootCause(error: Stripe.StripeError): { errorType: BillingErrorType, errorCode:BillingErrorCode } {
+    let errorType: BillingErrorType, errorCode: BillingErrorCode;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { statusCode, type, rawType, code, decline_code, } = error ;
+    // ----------------------------------------------------------------------------
+    // statusCode potential values: https://stripe.com/docs/api/errors
+    // ----------------------------------------------------------------------------
+    if (statusCode >= 500) {
+      errorType = BillingErrorType.PLATFORM_SERVER_ERROR;
+      errorCode = BillingErrorCode.UNEXPECTED_ERROR;
+    } else {
+      errorType = BillingErrorType.PLATFORM_APPLICATION_ERROR;
+      errorCode = BillingErrorCode.UNKNOWN_ERROR;
+    }
+    // ----------------------------------------------------------------------------
+    // TODO - Extract from the root cause the information that we need!
+    // type: c.f.: https://stripe.com/docs/api/errors/handling
+    // code: c.f.: https://stripe.com/docs/error-codes
+    // declineCode: c,f. https://stripe.com/docs/api/payouts/failures
+    // ----------------------------------------------------------------------------
+    if (error instanceof Stripe.errors.StripeInvalidRequestError) {
+      if (code === 'missing') {
+        // https://stripe.com/docs/error-codes#missing
+        errorCode = BillingErrorCode.NO_PAYMENT_METHOD;
+      }
+    } else if (error instanceof Stripe.errors.StripeCardError) {
+      errorType = BillingErrorType.PLATFORM_PAYMENT_ERROR;
+      errorCode = BillingErrorCode.CARD_ERROR;
+    }
+    // Let's return what we could determine as being the root cause!
+    return {
+      errorType,
+      errorCode
+    };
+  }
+
+  public static shrinkRootCause(error: Error): unknown {
+    // Reduce the size of the data that we save on our side!
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shrinkError: any = { ...error };
+    if (error instanceof Stripe.errors.StripeError) {
+      // Get rid of some properties
+      delete shrinkError.headers;
+      delete shrinkError.raw;
+    }
+    // Remove null and undefined properties
+    Object.keys(shrinkError).forEach((key) => {
+      const value = shrinkError[key];
+      // eslint-disable-next-line no-undefined
+      if (value === undefined || value === null) {
+        delete shrinkError[key];
+      }
+    });
+    return shrinkError;
   }
 }

--- a/src/integration/billing/stripe/StripeHelpers.ts
+++ b/src/integration/billing/stripe/StripeHelpers.ts
@@ -1,13 +1,7 @@
-import { BillingInvoice, BillingOperationResult } from '../../../types/Billing';
+import { BillingError, BillingInvoice, BillingOperationResult } from '../../../types/Billing';
 
 import BillingStorage from '../../../storage/mongodb/BillingStorage';
 import Stripe from 'stripe';
-
-export interface BillingError {
-  message: string
-  statusCode: number,
-  context?: unknown; // e.g.: payment ==> last_payment_error
-}
 
 export default class StripeHelpers {
 

--- a/src/storage/mongodb/BillingStorage.ts
+++ b/src/storage/mongodb/BillingStorage.ts
@@ -1,6 +1,7 @@
 import { BillingInvoice, BillingInvoiceDocument, BillingInvoiceStatus } from '../../types/Billing';
 import global, { FilterParams } from '../../types/GlobalType';
 
+import { BillingError } from '../../integration/billing/stripe/StripeHelpers';
 import Constants from '../../utils/Constants';
 import { DataResult } from '../../types/DataResult';
 import DatabaseUtils from './DatabaseUtils';
@@ -188,7 +189,7 @@ export default class BillingStorage {
     return invoiceMDB._id.toHexString();
   }
 
-  public static async saveLastPaymentFailure(tenantID: string, invoiceID: string, error: unknown): Promise<void> {
+  public static async saveLastPaymentFailure(tenantID: string, invoiceID: string, error: BillingError): Promise<void> {
     // Debug
     const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'savePaymentData');
     // Check Tenant

--- a/src/storage/mongodb/BillingStorage.ts
+++ b/src/storage/mongodb/BillingStorage.ts
@@ -1,7 +1,6 @@
-import { BillingInvoice, BillingInvoiceDocument, BillingInvoiceStatus } from '../../types/Billing';
+import { BillingError, BillingInvoice, BillingInvoiceStatus } from '../../types/Billing';
 import global, { FilterParams } from '../../types/GlobalType';
 
-import { BillingError } from '../../integration/billing/stripe/StripeHelpers';
 import Constants from '../../utils/Constants';
 import { DataResult } from '../../types/DataResult';
 import DatabaseUtils from './DatabaseUtils';

--- a/src/storage/mongodb/BillingStorage.ts
+++ b/src/storage/mongodb/BillingStorage.ts
@@ -188,15 +188,15 @@ export default class BillingStorage {
     return invoiceMDB._id.toHexString();
   }
 
-  public static async saveLastPaymentFailure(tenantID: string, invoiceID: string, error: BillingError): Promise<void> {
+  public static async saveLastBillingError(tenantID: string, invoiceID: string, error: BillingError): Promise<void> {
     // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'savePaymentData');
+    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'saveLastBillingError');
     // Check Tenant
     await DatabaseUtils.checkTenant(tenantID);
     // Set data
-    const updatedInvoiceMDB: any = {
-      lastPaymentFailure: {
-        eventReceivedOn: new Date(),
+    const updatedInvoiceMDB = {
+      lastBillingError: {
+        when: new Date(),
         error
       }
     };
@@ -205,7 +205,7 @@ export default class BillingStorage {
       { '_id': Utils.convertToObjectID(invoiceID) },
       { $set: updatedInvoiceMDB });
     // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'savePaymentData', uniqueTimerID, updatedInvoiceMDB);
+    await Logging.traceEnd(tenantID, MODULE_NAME, 'saveLastBillingError', uniqueTimerID, updatedInvoiceMDB);
   }
 
   public static async deleteInvoice(tenantID: string, id: string): Promise<void> {

--- a/src/types/Billing.ts
+++ b/src/types/Billing.ts
@@ -113,8 +113,8 @@ export interface BillingInvoiceDocument {
 
 export interface BillingOperationResult {
   succeeded: boolean
-  error?: BillingError
-  internalData?: unknown; // Object returned by the concrete implementation - e.g.: STRIPE
+  error?: Error
+  internalData?: unknown // an object returned by the concrete implementation - e.g.: STRIPE
 }
 
 export interface BillingPaymentMethod {
@@ -130,8 +130,4 @@ export interface BillingPaymentMethod {
 export interface BillingPaymentMethodResult {
   result: BillingPaymentMethod[];
   count: number;
-}
-export interface BillingError {
-  message: string
-  context?: unknown; // e.g.: payment ==> last_payment_error
 }

--- a/src/types/Billing.ts
+++ b/src/types/Billing.ts
@@ -128,8 +128,23 @@ export interface BillingPaymentMethod {
 }
 
 export interface BillingError {
-  // TODO - Billing Error should expose at least the information which is common to all payment platforms
+  // Billing Error should expose the information which is common to all payment platforms
   message: string
-  statusCode: number,
-  context?: unknown; // The context may provide additional information that are platform-specific
+  errorType: BillingErrorType, // SERVER or APPLICATION errors
+  errorCode: BillingErrorCode, // More information about the root cause
+  rootCause?: unknown; // The original error from the payment platform
+}
+
+export enum BillingErrorType {
+  APPLICATION_ERROR = 'application_error', // This is not a STRIPE error
+  PLATFORM_SERVER_ERROR = 'platform_server_error', // Errors 500, server is down or network issues
+  PLATFORM_APPLICATION_ERROR = 'platform_error', // This is a STRIPE error
+  PLATFORM_PAYMENT_ERROR = 'payment_error',
+}
+
+export enum BillingErrorCode {
+  UNKNOWN_ERROR = 'unknown',
+  UNEXPECTED_ERROR = 'unexpected',
+  NO_PAYMENT_METHOD = 'no_payment_method',
+  CARD_ERROR = 'card_error',
 }

--- a/src/types/Billing.ts
+++ b/src/types/Billing.ts
@@ -131,3 +131,10 @@ export interface BillingPaymentMethodResult {
   result: BillingPaymentMethod[];
   count: number;
 }
+
+export interface BillingError {
+  // TODO - Billing Error should expose at least the information which is common to all payment platforms
+  message: string
+  statusCode: number,
+  context?: unknown; // The context may provide additional information that are platform-specific
+}


### PR DESCRIPTION
**Better abstraction on Billing Errors**
a _BillingError_ interface has been added. it consists of:
- an error message
- a error type (enum)
- an error code (enum) 
- the root cause of the error (i.e.: The error sent by  payment platform itself)

**_StripeHelpers_ Class**
- helpers have been added to provide convenience methods for "consuming" Stripe Errors

**Billing Storage**
- _saveLastBillingError_ method can now persist the last operation error
- This is used to keep track the root cause of the problem when the invoice payment fails
-


