### PR TITLE
Refactor, cleanup and fix template application code:

### DIFF
--- a/src/assets/config-template-http.json
+++ b/src/assets/config-template-http.json
@@ -89,8 +89,8 @@
     "autoReconnectMaxRetries": 10,
     "autoReconnectTimeout": 60
   },
-	"AsyncTask" : {
-		"active" : true,
+  "AsyncTask": {
+    "active": true,
     "nbrTasksInParallel": 4
   },
   "Storage": {
@@ -170,22 +170,22 @@
     "active": false,
     "tasks": [
       {
-      "name": "OICPPushEVSEDataTask",
-      "active": false,
-      "periodicity": "*/10 * * * *",
-      "config": {
-        "processAllEVSEs": true
+        "name": "OICPPushEVSEDataTask",
+        "active": false,
+        "periodicity": "*/10 * * * *",
+        "config": {
+          "processAllEVSEs": true
+        }
+      },
+      {
+        "name": "OICPPushEvseStatusTask",
+        "active": false,
+        "periodicity": "*/5 * * * *",
+        "config": {
+          "processAllEVSEs": true
+        }
       }
-    },
-    {
-      "name": "OICPPushEvseStatusTask",
-      "active": false,
-      "periodicity": "*/5 * * * *",
-      "config": {
-        "processAllEVSEs": true
-      }
-    }
-  ]
+    ]
   },
   "Logging": {
     "logLevel": "D",

--- a/src/assets/config-template-https.json
+++ b/src/assets/config-template-https.json
@@ -69,7 +69,9 @@
     "port": 8443,
     "sslKey": "**insert key in PEM format**",
     "sslCert": "**insert certificate in PEM format**",
-    "sslCa": ["**insert certificate in PEM format**"],
+    "sslCa": [
+      "**insert certificate in PEM format**"
+    ],
     "debug": false,
     "externalProtocol": "https"
   },
@@ -97,8 +99,8 @@
   "OCPIEndpoint": {
     "baseUrl": ""
   },
-	"AsyncTask" : {
-		"active" : true,
+  "AsyncTask": {
+    "active": true,
     "nbrTasksInParallel": 4
   },
   "Storage": {
@@ -178,21 +180,22 @@
     "active": false,
     "tasks": [
       {
-      "name": "OICPPushEVSEDataTask",
-      "active": false,
-      "periodicity": "*/10 * * * *",
-      "config": {
-        "processAllEVSEs": true
+        "name": "OICPPushEVSEDataTask",
+        "active": false,
+        "periodicity": "*/10 * * * *",
+        "config": {
+          "processAllEVSEs": true
+        }
+      },
+      {
+        "name": "OICPPushEvseStatusTask",
+        "active": false,
+        "periodicity": "*/5 * * * *",
+        "config": {
+          "processAllEVSEs": true
+        }
       }
-    },
-    {
-      "name": "OICPPushEvseStatusTask",
-      "active": false,
-      "periodicity": "*/5 * * * *",
-      "config": {
-        "processAllEVSEs": true
-      }
-    }]
+    ]
   },
   "Logging": {
     "logLevel": "D",

--- a/src/integration/charging-station-vendor/ChargingStationVendorIntegration.ts
+++ b/src/integration/charging-station-vendor/ChargingStationVendorIntegration.ts
@@ -95,7 +95,6 @@ export default abstract class ChargingStationVendorIntegration {
         detailedMessages: { maxAmps, ocppParam: chargePoint.ocppParamForPowerLimitation, ocppLimitAmpValue: ocppLimitAmpValue }
       });
       // Change the OCPP Parameter
-      // TODO: Circular deps:
       result = await OCPPUtils.requestChangeChargingStationOcppParameter(tenantID, chargingStation, {
         key: chargePoint.ocppParamForPowerLimitation,
         value: ocppLimitAmpValue.toString()
@@ -155,7 +154,7 @@ export default abstract class ChargingStationVendorIntegration {
   public async setChargingProfile(tenantID: string, chargingStation: ChargingStation, chargePoint: ChargePoint,
       chargingProfile: ChargingProfile): Promise<OCPPSetChargingProfileCommandResult | OCPPSetChargingProfileCommandResult[]> {
     // Check if feature is supported
-    if (!chargingStation.capabilities || !chargingStation.capabilities.supportChargingProfiles) {
+    if (!chargingStation.capabilities?.supportChargingProfiles) {
       throw new BackendError({
         source: chargingStation.id,
         action: ServerAction.CHARGING_PROFILE_UPDATE,
@@ -233,7 +232,7 @@ export default abstract class ChargingStationVendorIntegration {
   public async clearChargingProfile(tenantID: string, chargingStation: ChargingStation,
       chargingProfile: ChargingProfile): Promise<OCPPClearChargingProfileCommandResult | OCPPClearChargingProfileCommandResult[]> {
     // Check if feature is supported
-    if (!chargingStation.capabilities || !chargingStation.capabilities.supportChargingProfiles) {
+    if (!chargingStation.capabilities?.supportChargingProfiles) {
       throw new BackendError({
         source: chargingStation.id,
         action: ServerAction.CHARGING_PROFILE_DELETE,
@@ -318,7 +317,7 @@ export default abstract class ChargingStationVendorIntegration {
   public async getCompositeSchedule(tenantID: string, chargingStation: ChargingStation, chargePoint: ChargePoint,
       connectorID: number, durationSecs: number): Promise<OCPPGetCompositeScheduleCommandResult> {
     // Check if feature is supported
-    if (!chargingStation.capabilities || !chargingStation.capabilities.supportChargingProfiles) {
+    if (!chargingStation.capabilities?.supportChargingProfiles) {
       throw new BackendError({
         source: chargingStation.id,
         action: ServerAction.CHARGING_STATION_GET_COMPOSITE_SCHEDULE,

--- a/src/scheduler/tasks/CheckChargingStationTemplateTask.ts
+++ b/src/scheduler/tasks/CheckChargingStationTemplateTask.ts
@@ -1,16 +1,11 @@
-import { OCPPChangeConfigurationCommandResult, OCPPConfigurationStatus } from '../../types/ocpp/OCPPClient';
-
-import { ActionsResponse } from '../../types/GlobalType';
 import ChargingStationStorage from '../../storage/mongodb/ChargingStationStorage';
 import Constants from '../../utils/Constants';
 import { LockEntity } from '../../types/Locking';
 import LockingManager from '../../locking/LockingManager';
 import Logging from '../../utils/Logging';
-import { OCPPPhase } from '../../types/ocpp/OCPPServer';
 import OCPPUtils from '../../server/ocpp/utils/OCPPUtils';
 import SchedulerTask from '../SchedulerTask';
 import { ServerAction } from '../../types/Server';
-import { StaticLimitAmps } from '../../types/ChargingStation';
 import { TaskConfig } from '../../types/TaskConfig';
 import Tenant from '../../types/Tenant';
 import Utils from '../../utils/Utils';
@@ -61,108 +56,9 @@ export default class CheckChargingStationTemplateTask extends SchedulerTask {
     // Update
     for (const chargingStation of chargingStations.result) {
       try {
-        const chargingStationTemplateUpdated = await OCPPUtils.enrichChargingStationWithTemplate(tenant.id, chargingStation);
-        // Enrich
-        let chargingStationUpdated = false;
-        // Check Connectors
-        for (const connector of chargingStation.connectors) {
-          // Amperage limit
-          const connectorAmperageLimitMax = Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
-          const numberOfPhases = Utils.getNumberOfConnectedPhases(chargingStation, null, connector.connectorId);
-          const numberOfConnectors = chargingStation.connectors.length;
-          const connectorAmperageLimitMin = StaticLimitAmps.MIN_LIMIT_PER_PHASE * numberOfPhases * numberOfConnectors;
-          if (!Utils.objectHasProperty(connector, 'amperageLimit') || (Utils.objectHasProperty(connector, 'amperageLimit') && Utils.isNullOrUndefined(connector.amperageLimit))) {
-            connector.amperageLimit = connectorAmperageLimitMax;
-            chargingStationUpdated = true;
-          } else if (Utils.objectHasProperty(connector, 'amperageLimit') && connector.amperageLimit > connectorAmperageLimitMax) {
-            connector.amperageLimit = connectorAmperageLimitMax;
-            chargingStationUpdated = true;
-          } else if (Utils.objectHasProperty(connector, 'amperageLimit') && connector.amperageLimit < connectorAmperageLimitMin) {
-            connector.amperageLimit = connectorAmperageLimitMin;
-            chargingStationUpdated = true;
-          }
-          // Phase Assignment
-          if (!Utils.objectHasProperty(connector, 'phaseAssignmentToGrid')) {
-            // Phase Assignment to Grid has to be handled only for Site Area with 3 phases
-            if (chargingStation?.siteArea?.numberOfPhases === 3) {
-              // Single Phase
-              if (numberOfPhases === 1) {
-                connector.phaseAssignmentToGrid = { csPhaseL1: OCPPPhase.L1, csPhaseL2: null, csPhaseL3: null };
-              // Tri-phase
-              } else if (numberOfPhases === 3) {
-                connector.phaseAssignmentToGrid = { csPhaseL1: OCPPPhase.L1, csPhaseL2: OCPPPhase.L2, csPhaseL3: OCPPPhase.L3 };
-              }
-            } else {
-              connector.phaseAssignmentToGrid = null;
-            }
-            chargingStationUpdated = true;
-          }
-        }
-        // Save
-        if (chargingStationTemplateUpdated.technicalUpdated ||
-            chargingStationTemplateUpdated.capabilitiesUpdated ||
-            chargingStationTemplateUpdated.ocppStandardUpdated ||
-            chargingStationTemplateUpdated.ocppVendorUpdated ||
-            chargingStationUpdated) {
-          const sectionsUpdated = [];
-          if (chargingStationTemplateUpdated.technicalUpdated) {
-            sectionsUpdated.push('Technical');
-          }
-          if (chargingStationTemplateUpdated.capabilitiesUpdated) {
-            sectionsUpdated.push('Capabilities');
-          }
-          if (chargingStationTemplateUpdated.ocppStandardUpdated || chargingStationTemplateUpdated.ocppVendorUpdated) {
-            sectionsUpdated.push('OCPP');
-          }
-          await Logging.logInfo({
-            tenantID: tenant.id,
-            source: chargingStation.id,
-            action: ServerAction.UPDATE_CHARGING_STATION_WITH_TEMPLATE,
-            module: MODULE_NAME, method: 'applyTemplateToChargingStations',
-            message: `Charging Station '${chargingStation.id}' updated with the following Template's section(s): ${sectionsUpdated.join(', ')}`,
-            detailedMessages: { chargingStationUpdated, chargingStationTemplateUpdated }
-          });
-          // Save
-          await ChargingStationStorage.saveChargingStation(tenant.id, chargingStation);
+        const chargingStationTemplateUpdateResult = await OCPPUtils.applyTemplateToChargingStation(tenant.id, chargingStation);
+        if (chargingStationTemplateUpdateResult.chargingStationUpdated) {
           updated++;
-          // Retrieve OCPP parameters and update them if needed
-          if (chargingStationTemplateUpdated.ocppStandardUpdated || chargingStationTemplateUpdated.ocppVendorUpdated) {
-            await Logging.logDebug({
-              tenantID: tenant.id,
-              action: ServerAction.UPDATE_CHARGING_STATION_WITH_TEMPLATE,
-              source: chargingStation.id,
-              module: MODULE_NAME, method: 'applyTemplateToChargingStations',
-              message: `Apply Template's OCPP Parameters for '${chargingStation.id}' in Tenant ${Utils.buildTenantName(tenant)})`,
-            });
-            // Request the latest configuration
-            const result = await Utils.executePromiseWithTimeout<OCPPChangeConfigurationCommandResult>(
-              Constants.DELAY_REQUEST_CONFIGURATION_EXECUTION_MILLIS, OCPPUtils.requestAndSaveChargingStationOcppParameters(tenant.id, chargingStation),
-              `Time out error (${Constants.DELAY_REQUEST_CONFIGURATION_EXECUTION_MILLIS}ms) in requesting OCPP Parameters`);
-            if (result.status !== OCPPConfigurationStatus.ACCEPTED) {
-              await Logging.logError({
-                tenantID: tenant.id,
-                action: ServerAction.UPDATE_CHARGING_STATION_WITH_TEMPLATE,
-                source: chargingStation.id,
-                module: MODULE_NAME, method: 'applyTemplateToChargingStations',
-                message: `Cannot request OCPP Parameters from '${chargingStation.id}' in Tenant ${Utils.buildTenantName(tenant)})`,
-              });
-              continue;
-            }
-            // Update the OCPP Parameters from the template
-            const updatedOcppParameters = await Utils.executePromiseWithTimeout<ActionsResponse>(
-              Constants.DELAY_REQUEST_CONFIGURATION_EXECUTION_MILLIS, OCPPUtils.updateChargingStationTemplateOcppParameters(tenant.id, chargingStation),
-              `Time out error (${Constants.DELAY_REQUEST_CONFIGURATION_EXECUTION_MILLIS}ms) in updating OCPP Parameters`);
-            // Log
-            await Logging.logActionsResponse(
-              tenant.id,
-              ServerAction.UPDATE_CHARGING_STATION_WITH_TEMPLATE,
-              MODULE_NAME, 'applyTemplateToChargingStations', updatedOcppParameters,
-              `{{inSuccess}} OCPP Parameter(s) were successfully synchronized, check details in the Tenant ${Utils.buildTenantName(tenant)})`,
-              `{{inError}} OCPP Parameter(s) failed to be synchronized, check details in the Tenant ${Utils.buildTenantName(tenant)})`,
-              `{{inSuccess}} OCPP Parameter(s) were successfully synchronized and {{inError}} failed to be synchronized, check details in the Tenant ${Utils.buildTenantName(tenant)})`,
-              'All the OCPP Parameters are up to date'
-            );
-          }
         }
       } catch (error) {
         await Logging.logError({

--- a/src/scheduler/tasks/CheckOfflineChargingStationsTask.ts
+++ b/src/scheduler/tasks/CheckOfflineChargingStationsTask.ts
@@ -42,7 +42,7 @@ export default class CheckOfflineChargingStationsTask extends SchedulerTask {
             }
             // Charging Station is still connected: ignore it
             if (ocppHeartbeatConfiguration) {
-              Logging.logInfo({
+              await Logging.logInfo({
                 tenantID: tenant.id,
                 source: chargingStation.id,
                 action: ServerAction.OFFLINE_CHARGING_STATION,
@@ -75,7 +75,7 @@ export default class CheckOfflineChargingStationsTask extends SchedulerTask {
         }
       } catch (error) {
         // Log error
-        Logging.logActionExceptionMessage(tenant.id, ServerAction.OFFLINE_CHARGING_STATION, error);
+        await Logging.logActionExceptionMessage(tenant.id, ServerAction.OFFLINE_CHARGING_STATION, error);
       } finally {
         // Release the lock
         await LockingManager.release(offlineChargingStationLock);

--- a/src/scheduler/tasks/CheckPreparingSessionNotStartedTask.ts
+++ b/src/scheduler/tasks/CheckPreparingSessionNotStartedTask.ts
@@ -49,7 +49,7 @@ export default class CheckPreparingSessionNotStartedTask extends SchedulerTask {
         }
       } catch (error) {
         // Log error
-        Logging.logActionExceptionMessage(tenant.id, ServerAction.PREPARING_SESSION_NOT_STARTED, error);
+        await Logging.logActionExceptionMessage(tenant.id, ServerAction.PREPARING_SESSION_NOT_STARTED, error);
       } finally {
         // Release the lock
         await LockingManager.release(sessionNotStartedLock);

--- a/src/scheduler/tasks/CheckSessionNotStartedAfterAuthorizeTask.ts
+++ b/src/scheduler/tasks/CheckSessionNotStartedAfterAuthorizeTask.ts
@@ -33,7 +33,7 @@ export default class CheckSessionNotStartedAfterAuthorizeTask extends SchedulerT
         }
       } catch (error) {
         // Log error
-        Logging.logActionExceptionMessage(tenant.id, ServerAction.PREPARING_SESSION_NOT_STARTED, error);
+        await Logging.logActionExceptionMessage(tenant.id, ServerAction.PREPARING_SESSION_NOT_STARTED, error);
       } finally {
         // Release the lock
         await LockingManager.release(sessionNotStartedLock);

--- a/src/server/ocpp/json/JsonWSConnection.ts
+++ b/src/server/ocpp/json/JsonWSConnection.ts
@@ -123,13 +123,14 @@ export default class JsonWSConnection extends WSConnection {
   public async handleRequest(messageId: string, commandName: ServerAction, commandPayload: Record<string, unknown> | string): Promise<void> {
     // Log
     await Logging.logChargingStationServerReceiveAction(MODULE_NAME, this.getTenantID(), this.getChargingStationID(), commandName, commandPayload);
+    const methodName = `handle${commandName}`;
     // Check if method exist in the service
-    if (typeof this.chargingStationService['handle' + commandName] === 'function') {
+    if (typeof this.chargingStationService[methodName] === 'function') {
       if ((commandName === 'BootNotification') || (commandName === 'Heartbeat')) {
         this.headers.currentIPAddress = this.getClientIP();
       }
       // Call it
-      const result = await this.chargingStationService['handle' + commandName](this.headers, commandPayload);
+      const result = await this.chargingStationService[methodName](this.headers, commandPayload);
       // Log
       await Logging.logChargingStationServerRespondAction(MODULE_NAME, this.getTenantID(), this.getChargingStationID(), commandName, result);
       // Send Response

--- a/src/server/ocpp/json/services/JsonChargingStationService.ts
+++ b/src/server/ocpp/json/services/JsonChargingStationService.ts
@@ -113,9 +113,9 @@ export default class JsonChargingStationService {
   private async handle(command: ServerAction, headers: OCPPHeader, payload) {
     try {
       // Handle
-      return await this.chargingStationService['handle' + command](headers, payload);
+      return await this.chargingStationService[`handle${command}`](headers, payload);
     } catch (error) {
-      Logging.logException(error, command, headers.chargeBoxIdentity, MODULE_NAME, command, headers.tenantID);
+      await Logging.logException(error, command, headers.chargeBoxIdentity, MODULE_NAME, command, headers.tenantID);
       throw error;
     }
   }

--- a/src/server/ocpp/services/OCPPService.ts
+++ b/src/server/ocpp/services/OCPPService.ts
@@ -180,10 +180,15 @@ export default class OCPPService {
         chargingStation.cfApplicationIDAndInstanceIndex = Configuration.getCFApplicationIDAndInstanceIndex();
       }
       const currentTenant = await TenantStorage.getTenant(headers.tenantID);
-      // Enrich Charging Station from templates
-      const chargingStationTemplateUpdateResult = await OCPPUtils.enrichChargingStationWithTemplate(headers.tenantID, chargingStation);
-      // Save Charging Station
-      await ChargingStationStorage.saveChargingStation(headers.tenantID, chargingStation);
+      // Apply Charging Station Template
+      const chargingStationTemplateUpdateResult = await OCPPUtils.applyTemplateToChargingStation(headers.tenantID, chargingStation, false);
+      // No matching template or manual configuration
+      if (!chargingStationTemplateUpdateResult.chargingStationUpdated) {
+        OCPPUtils.checkAndSetChargingStationAmperageLimit(chargingStation);
+        await OCPPUtils.setChargingStationPhaseAssignment(headers.tenantID, chargingStation);
+        // Save Charging Station
+        await ChargingStationStorage.saveChargingStation(headers.tenantID, chargingStation);
+      }
       // Save Boot Notification
       await OCPPStorage.saveBootNotification(headers.tenantID, bootNotification);
       // Send Notification (Async)
@@ -239,9 +244,10 @@ export default class OCPPService {
             message: `Cannot set heartbeat interval OCPP Parameter on '${chargingStation.id}' in Tenant '${currentTenant.name}' ('${currentTenant.subdomain}')`,
           });
         }
-        // Get config and save it
-        result = await OCPPUtils.requestAndSaveChargingStationOcppParameters(headers.tenantID, chargingStation,
-          chargingStationTemplateUpdateResult.ocppStandardUpdated || chargingStationTemplateUpdateResult.ocppVendorUpdated);
+        // Apply Charging Station Template OCPP configuration
+        if (chargingStationTemplateUpdateResult.ocppStandardUpdated || chargingStationTemplateUpdateResult.ocppVendorUpdated) {
+          result = await OCPPUtils.applyTemplateOcppParametersToChargingStation(headers.tenantID, chargingStation);
+        }
         if (result.status !== OCPPConfigurationStatus.ACCEPTED) {
           await Logging.logError({
             tenantID: headers.tenantID,
@@ -251,7 +257,7 @@ export default class OCPPService {
             message: `Cannot request and save OCPP Parameters from '${chargingStation.id}' in Tenant '${currentTenant.name}' ('${currentTenant.subdomain}')`,
           });
         }
-      }, Constants.DELAY_REQUEST_CONFIGURATION_EXECUTION_MILLIS);
+      }, Constants.DELAY_CHANGE_CONFIGURATION_EXECUTION_MILLIS);
       // Return the result
       return {
         currentTime: bootNotification.timestamp.toISOString(),
@@ -530,7 +536,8 @@ export default class OCPPService {
     }
   }
 
-  public async handleDiagnosticsStatusNotification(headers: OCPPHeader, diagnosticsStatusNotification: OCPPDiagnosticsStatusNotificationRequestExtended): Promise<OCPPDiagnosticsStatusNotificationResponse> {
+  public async handleDiagnosticsStatusNotification(headers: OCPPHeader,
+      diagnosticsStatusNotification: OCPPDiagnosticsStatusNotificationRequestExtended): Promise<OCPPDiagnosticsStatusNotificationResponse> {
     try {
       // Get the charging station
       const chargingStation = await OCPPUtils.checkAndGetChargingStation(headers.chargeBoxIdentity, headers.tenantID);
@@ -562,7 +569,8 @@ export default class OCPPService {
     }
   }
 
-  public async handleFirmwareStatusNotification(headers: OCPPHeader, firmwareStatusNotification: OCPPFirmwareStatusNotificationRequestExtended): Promise<OCPPFirmwareStatusNotificationResponse> {
+  public async handleFirmwareStatusNotification(headers: OCPPHeader,
+      firmwareStatusNotification: OCPPFirmwareStatusNotificationRequestExtended): Promise<OCPPFirmwareStatusNotificationResponse> {
     try {
       // Get the charging station
       const chargingStation = await OCPPUtils.checkAndGetChargingStation(headers.chargeBoxIdentity, headers.tenantID);

--- a/src/server/rest/v1/service/SiteAreaService.ts
+++ b/src/server/rest/v1/service/SiteAreaService.ts
@@ -561,6 +561,7 @@ export default class SiteAreaService {
     await SiteAreaStorage.saveSiteArea(req.user.tenantID, siteArea, Utils.objectHasProperty(filteredRequest, 'image'));
     // Retrigger Smart Charging
     if (filteredRequest.smartCharging) {
+      // FIXME: the lock acquisition can wait for 30s before timeout and the whole code execution timeout at 3s
       // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-undef
       setTimeout(async () => {
         const siteAreaLock = await LockingHelper.tryCreateSiteAreaSmartChargingLock(req.user.tenantID, siteArea, 30 * 1000);

--- a/src/storage/mongodb/ChargingStationStorage.ts
+++ b/src/storage/mongodb/ChargingStationStorage.ts
@@ -1039,7 +1039,7 @@ export default class ChargingStationStorage {
         type: connector.type,
         voltage: Utils.convertToInt(connector.voltage),
         amperage: Utils.convertToInt(connector.amperage),
-        amperageLimit: connector.amperageLimit,
+        amperageLimit: Utils.convertToInt(connector.amperageLimit),
         currentTransactionID: Utils.convertToInt(connector.currentTransactionID),
         userID: Utils.convertToObjectID(connector.userID),
         statusLastChangedOn: Utils.convertToDate(connector.statusLastChangedOn),
@@ -1047,12 +1047,12 @@ export default class ChargingStationStorage {
         numberOfConnectedPhase: connector.numberOfConnectedPhase,
         currentType: connector.currentType,
         chargePointID: connector.chargePointID,
-        phaseAssignmentToGrid: connector.phaseAssignmentToGrid ?
+        phaseAssignmentToGrid: connector.phaseAssignmentToGrid &&
           {
             csPhaseL1: connector.phaseAssignmentToGrid.csPhaseL1,
             csPhaseL2: connector.phaseAssignmentToGrid.csPhaseL2,
             csPhaseL3: connector.phaseAssignmentToGrid.csPhaseL3,
-          } : null,
+          },
       };
       return filteredConnector;
     }

--- a/src/types/ChargingStation.ts
+++ b/src/types/ChargingStation.ts
@@ -85,6 +85,7 @@ export interface TemplateUpdate {
 }
 
 export interface TemplateUpdateResult {
+  chargingStationUpdated: boolean;
   technicalUpdated: boolean;
   capabilitiesUpdated: boolean;
   ocppStandardUpdated: boolean;

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -227,7 +227,7 @@ export default class Constants {
   public static readonly REST_RESPONSE_SUCCESS = Object.freeze({ status: 'Success' });
 
   public static readonly DELAY_SMART_CHARGING_EXECUTION_MILLIS = 3000;
-  public static readonly DELAY_REQUEST_CONFIGURATION_EXECUTION_MILLIS = 3000;
+  public static readonly DELAY_CHANGE_CONFIGURATION_EXECUTION_MILLIS = 10000;
 
   public static readonly CHARGING_STATION_CONFIGURATION = 'Configuration';
 

--- a/test/api/context/ChargingStationContext.ts
+++ b/test/api/context/ChargingStationContext.ts
@@ -434,8 +434,9 @@ export default class ChargingStationContext {
       connector.timestamp = new Date().toISOString();
     }
     const response = await this.ocppService.executeStatusNotification(this.chargingStation.id, connector);
-    this.chargingStation.connectors[connector.connectorId - 1].status = connector.status;
-    this.chargingStation.connectors[connector.connectorId - 1].errorCode = connector.errorCode;
+    const connectorId = connector.connectorId - 1;
+    this.chargingStation.connectors[connectorId].status = connector.status;
+    this.chargingStation.connectors[connectorId].errorCode = connector.errorCode;
     return response;
   }
 

--- a/test/api/ocpp/json/OCPPJsonService16.ts
+++ b/test/api/ocpp/json/OCPPJsonService16.ts
@@ -81,8 +81,9 @@ export default class OCPPJsonService16 extends OCPPService {
 
   public async handleRequest(chargeBoxIdentity: string, messageId: string, commandName: ServerAction, commandPayload: Record<string, unknown> | string): Promise<void> {
     let result = {};
-    if (this.requestHandler && typeof this.requestHandler['handle' + commandName] === 'function') {
-      result = await this.requestHandler['handle' + commandName](commandPayload);
+    const methodName = `handle${commandName}`;
+    if (this.requestHandler && typeof this.requestHandler[methodName] === 'function') {
+      result = await this.requestHandler[methodName](commandPayload);
     }
     await this.send(chargeBoxIdentity, this.buildResponse(messageId, result));
   }


### PR DESCRIPTION
+ Unify OCPP param handling return type;
+ Push down default settings handling in template: fix dynamic connector
  adding (e.g. slave)
+ Fix no template at boot notification handling (manual configuration)
+ Improve log message
+ Fix forced template OCPP params application
+ ... too much to list ...

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>