### PR TITLE
eslint - typescript-eslint/no-shadow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,7 +81,8 @@
     ],
     "no-useless-catch": "error",
     "no-useless-return": "error",
-    "no-shadow": "error",
+    "no-shadow": "off", // This one is generating false positive no-shadow errors on exported/const enums
+    "@typescript-eslint/no-shadow": "error",
     "no-multiple-empty-lines": [
       "error",
       {


### PR DESCRIPTION
eslint conf change to avoid np-shadow false positive errors

![image](https://user-images.githubusercontent.com/26900551/114420175-640e2800-9bb4-11eb-84f2-0dafd1f98b78.png)
