### PR TITLE
Billing - settings - explicit activation

### DIFF
--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -282,16 +282,6 @@ export default abstract class BillingIntegration {
         action: ServerAction.BILLING_TRANSACTION
       });
     }
-    // Check Charging Station
-    if (transaction?.billingData?.invoiceID) {
-      throw new BackendError({
-        message: 'Transaction has already billing data',
-        source: Constants.CENTRAL_SERVER,
-        module: MODULE_NAME,
-        method: 'checkStopTransaction',
-        action: ServerAction.BILLING_TRANSACTION
-      });
-    }
     if (this.productionMode) {
       // Check Billing Data (only in Live Mode)
       if (!transaction.user.billingData) {

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -637,7 +637,8 @@ export default class StripeBillingIntegration extends BillingIntegration {
 
     if (!this.settings.billing.isTransactionBillingActivated) {
       return {
-        isTransactionBillingActivated: false
+        // Keeps track whether the billing was activated or not on start transaction
+        withBillingActive: false
       };
     }
 
@@ -670,7 +671,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       });
     }
     return {
-      isTransactionBillingActivated: true
+      withBillingActive: true
     };
   }
 
@@ -687,7 +688,8 @@ export default class StripeBillingIntegration extends BillingIntegration {
       });
     }
     return {
-      isTransactionBillingActivated: true
+      // Just propagate the initial state
+      withBillingActive: transaction.billingData?.withBillingActive
     };
   }
 
@@ -747,10 +749,8 @@ export default class StripeBillingIntegration extends BillingIntegration {
   }
 
   public async stopTransaction(transaction: Transaction): Promise<BillingDataTransactionStop> {
-    if (!transaction.billingData.isTransactionBillingActivated) {
-      // --------------------------------------------------------------------
-      // The billing feature has been activated after the startTransaction
-      // --------------------------------------------------------------------
+    // Check whether the billing was activated on start transaction
+    if (!transaction.billingData.withBillingActive) {
       return {
         status: BillingStatus.UNBILLED
       };

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -634,6 +634,13 @@ export default class StripeBillingIntegration extends BillingIntegration {
   }
 
   public async startTransaction(transaction: Transaction): Promise<BillingDataTransactionStart> {
+
+    if (!this.settings.billing.isTransactionBillingActivated) {
+      return {
+        isTransactionBillingActivated: false
+      };
+    }
+
     // Check Stripe
     await this.checkConnection();
     // Check Transaction
@@ -663,7 +670,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       });
     }
     return {
-      cancelTransaction: false
+      isTransactionBillingActivated: true
     };
   }
 
@@ -680,7 +687,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       });
     }
     return {
-      cancelTransaction: false
+      isTransactionBillingActivated: true
     };
   }
 
@@ -740,6 +747,14 @@ export default class StripeBillingIntegration extends BillingIntegration {
   }
 
   public async stopTransaction(transaction: Transaction): Promise<BillingDataTransactionStop> {
+    if (!transaction.billingData.isTransactionBillingActivated) {
+      // --------------------------------------------------------------------
+      // The billing feature has been activated after the startTransaction
+      // --------------------------------------------------------------------
+      return {
+        status: BillingStatus.UNBILLED
+      };
+    }
     // Check Stripe
     await this.checkConnection();
     // Check object

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -1,3 +1,4 @@
+import { BillingDataTransactionStart, BillingDataTransactionStop } from '../../../types/Billing';
 import { ChargingProfile, ChargingProfilePurposeType } from '../../../types/ChargingProfile';
 import ChargingStation, { ChargingStationCapabilities, ChargingStationOcppParameters, ChargingStationTemplate, Connector, ConnectorCurrentLimitSource, CurrentType, OcppParameter, SiteAreaLimitSource, StaticLimitAmps, TemplateUpdate, TemplateUpdateResult } from '../../../types/ChargingStation';
 import { OCPPAuthorizeRequestExtended, OCPPMeasurand, OCPPMeterValue, OCPPNormalizedMeterValue, OCPPPhase, OCPPReadingContext, OCPPStopTransactionRequestExtended, OCPPUnitOfMeasure, OCPPValueFormat } from '../../../types/ocpp/OCPPServer';
@@ -6,7 +7,6 @@ import Transaction, { InactivityStatus, TransactionAction, TransactionStop } fro
 
 import { ActionsResponse } from '../../../types/GlobalType';
 import BackendError from '../../../exception/BackendError';
-import { BillingDataTransactionStop } from '../../../types/Billing';
 import BillingFactory from '../../../integration/billing/BillingFactory';
 import ChargingStationClientFactory from '../../../client/ocpp/ChargingStationClientFactory';
 import ChargingStationStorage from '../../../storage/mongodb/ChargingStationStorage';
@@ -316,7 +316,6 @@ export default class OCPPUtils {
   }
 
   public static async billTransaction(tenantID: string, transaction: Transaction, action: TransactionAction): Promise<void> {
-    let billingDataStop: BillingDataTransactionStop;
     const billingImpl = await BillingFactory.getBillingImpl(tenantID);
     if (billingImpl) {
       // Check
@@ -325,9 +324,10 @@ export default class OCPPUtils {
         case TransactionAction.START:
           try {
             // Delegate
-            await billingImpl.startTransaction(transaction);
+            const billingDataTransactionStart: BillingDataTransactionStart = await billingImpl.startTransaction(transaction);
             // Update
             transaction.billingData = {
+              isTransactionBillingActivated: billingDataTransactionStart.isTransactionBillingActivated,
               lastUpdate: new Date()
             };
           } catch (error) {
@@ -365,12 +365,9 @@ export default class OCPPUtils {
         case TransactionAction.STOP:
           try {
             // Delegate
-            billingDataStop = await billingImpl.stopTransaction(transaction);
+            const billingDataStop: BillingDataTransactionStop = await billingImpl.stopTransaction(transaction);
             // Update
-            transaction.billingData.status = billingDataStop.status;
-            transaction.billingData.invoiceID = billingDataStop.invoiceID;
-            transaction.billingData.invoiceStatus = billingDataStop.invoiceStatus;
-            transaction.billingData.invoiceItem = billingDataStop.invoiceItem;
+            transaction.billingData.stop = billingDataStop;
             transaction.billingData.lastUpdate = new Date();
           } catch (error) {
             await Logging.logError({

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -327,7 +327,7 @@ export default class OCPPUtils {
             const billingDataTransactionStart: BillingDataTransactionStart = await billingImpl.startTransaction(transaction);
             // Update
             transaction.billingData = {
-              isTransactionBillingActivated: billingDataTransactionStart.isTransactionBillingActivated,
+              withBillingActive: billingDataTransactionStart.withBillingActive,
               lastUpdate: new Date()
             };
           } catch (error) {

--- a/src/server/rest/v1/service/BillingService.ts
+++ b/src/server/rest/v1/service/BillingService.ts
@@ -450,15 +450,16 @@ export default class BillingService {
     UtilsService.assertObjectExists(action, transaction, `Transaction ID '${filteredRequest.transactionID}' does not exist`,
       MODULE_NAME, 'handleCreateTransactionInvoice', req.user);
     // Create an invoice for the transaction
+    // ----------------------------------------------------------------------
+    // TODO - Rethink that part!
+    // Calling StopTransaction without calling startTransaction may have
+    // unpredictable side-effects.
+    // ----------------------------------------------------------------------
     const billingDataStop = await billingImpl.stopTransaction(transaction);
-    // Update transaction
-    transaction.billingData = {
-      status: billingDataStop.status,
-      invoiceID: billingDataStop.invoiceID,
-      invoiceStatus: billingDataStop.invoiceStatus,
-      invoiceItem: billingDataStop.invoiceItem,
-      lastUpdate: new Date()
-    };
+    // Update transaction billing data
+    transaction.billingData.stop = billingDataStop;
+    transaction.billingData.lastUpdate = new Date();
+    // Save it
     await TransactionStorage.saveTransaction(req.user.tenantID, transaction);
     // Ok
     await Logging.logInfo({

--- a/src/server/rest/v1/service/TransactionService.ts
+++ b/src/server/rest/v1/service/TransactionService.ts
@@ -8,6 +8,7 @@ import AppAuthError from '../../../../exception/AppAuthError';
 import AppError from '../../../../exception/AppError';
 import Authorizations from '../../../../authorization/Authorizations';
 import BillingFactory from '../../../../integration/billing/BillingFactory';
+import { BillingStatus } from '../../../../types/Billing';
 import ChargingStationStorage from '../../../../storage/mongodb/ChargingStationStorage';
 import Configuration from '../../../../utils/Configuration';
 import Constants from '../../../../utils/Constants';
@@ -15,7 +16,6 @@ import Consumption from '../../../../types/Consumption';
 import ConsumptionStorage from '../../../../storage/mongodb/ConsumptionStorage';
 import Cypher from '../../../../utils/Cypher';
 import { DataResult } from '../../../../types/DataResult';
-import I18nManager from '../../../../utils/I18nManager';
 import LockingHelper from '../../../../locking/LockingHelper';
 import LockingManager from '../../../../locking/LockingManager';
 import Logging from '../../../../utils/Logging';
@@ -980,7 +980,7 @@ export default class TransactionService {
           detailedMessages: { transaction }
         });
         // Billed
-      } else if (billingImpl && transaction.billingData && transaction.billingData.invoiceID) {
+      } else if (billingImpl && transaction.billingData?.stop?.status === BillingStatus.BILLED) {
         result.inError++;
         await Logging.logError({
           tenantID: loggedUser.tenantID,

--- a/src/server/rest/v1/service/security/SettingSecurity.ts
+++ b/src/server/rest/v1/service/security/SettingSecurity.ts
@@ -174,6 +174,7 @@ export default class SettingSecurity {
           break;
         case BillingSettingsType.STRIPE:
           settings.content.billing = {
+            isTransactionBillingActivated : sanitize(request.content.billing.isTransactionBillingActivated),
             immediateBillingAllowed: sanitize(request.content.billing.immediateBillingAllowed),
             periodicBillingAllowed: sanitize(request.content.billing.periodicBillingAllowed),
             taxID: sanitize(request.content.billing.taxID)

--- a/src/storage/mongodb/SettingStorage.ts
+++ b/src/storage/mongodb/SettingStorage.ts
@@ -301,8 +301,9 @@ export default class SettingStorage {
       billingSettings.backupSensitiveData = settings.result[0].backupSensitiveData;
       // Billing Common Properties
       if (config.billing) {
-        const { immediateBillingAllowed, periodicBillingAllowed, taxID, usersLastSynchronizedOn } = config.billing;
+        const { isTransactionBillingActivated, immediateBillingAllowed, periodicBillingAllowed, taxID, usersLastSynchronizedOn } = config.billing;
         billingSettings.billing = {
+          isTransactionBillingActivated,
           immediateBillingAllowed,
           periodicBillingAllowed,
           usersLastSynchronizedOn,

--- a/src/storage/mongodb/TransactionStorage.ts
+++ b/src/storage/mongodb/TransactionStorage.ts
@@ -168,11 +168,14 @@ export default class TransactionStorage {
     }
     if (transactionToSave.billingData) {
       transactionMDB.billingData = {
-        status: transactionToSave.billingData.status,
-        invoiceID: Utils.convertToObjectID(transactionToSave.billingData.invoiceID),
-        invoiceStatus: transactionToSave.billingData.invoiceStatus,
-        invoiceItem: transactionToSave.billingData.invoiceItem,
+        isTransactionBillingActivated: transactionToSave.billingData.isTransactionBillingActivated,
         lastUpdate: Utils.convertToDate(transactionToSave.billingData.lastUpdate),
+        stop: {
+          status: transactionToSave.billingData.stop?.status,
+          invoiceID: Utils.convertToObjectID(transactionToSave.billingData.stop?.invoiceID),
+          invoiceStatus: transactionToSave.billingData.stop?.invoiceStatus,
+          invoiceItem: transactionToSave.billingData.stop?.invoiceItem,
+        },
       };
     }
     if (transactionToSave.ocpiData) {

--- a/src/storage/mongodb/TransactionStorage.ts
+++ b/src/storage/mongodb/TransactionStorage.ts
@@ -168,7 +168,7 @@ export default class TransactionStorage {
     }
     if (transactionToSave.billingData) {
       transactionMDB.billingData = {
-        isTransactionBillingActivated: transactionToSave.billingData.isTransactionBillingActivated,
+        withBillingActive: transactionToSave.billingData.withBillingActive,
         lastUpdate: Utils.convertToDate(transactionToSave.billingData.lastUpdate),
         stop: {
           status: transactionToSave.billingData.stop?.status,
@@ -1285,8 +1285,9 @@ export default class TransactionStorage {
             $match: {
               $or: [
                 { 'billingData': { $exists: false } },
-                { 'billingData.invoiceID': { $exists: false } },
-                { 'billingData.invoiceID': { $eq: null } }
+                { 'billingData.stop': { $exists: false } },
+                { 'billingData.stop.invoiceID': { $exists: false } },
+                { 'billingData.stop.invoiceID': { $eq: null } }
               ]
             }
           },

--- a/src/types/Billing.ts
+++ b/src/types/Billing.ts
@@ -3,17 +3,17 @@ import { ActionsResponse, DocumentEncoding, DocumentType } from './GlobalType';
 import User from './User';
 
 export interface BillingTransactionData {
-  isTransactionBillingActivated?: boolean;
+  withBillingActive?: boolean;
   lastUpdate?: Date;
   stop?: BillingDataTransactionStop;
 }
 
 export interface BillingDataTransactionStart {
-  isTransactionBillingActivated: boolean;
+  withBillingActive: boolean;
 }
 
 export interface BillingDataTransactionUpdate {
-  isTransactionBillingActivated: boolean;
+  withBillingActive: boolean;
 }
 
 export enum BillingStatus {

--- a/src/types/Billing.ts
+++ b/src/types/Billing.ts
@@ -3,19 +3,17 @@ import { ActionsResponse, DocumentEncoding, DocumentType } from './GlobalType';
 import User from './User';
 
 export interface BillingTransactionData {
-  status?: string;
-  invoiceID?: string;
-  invoiceStatus?: BillingInvoiceStatus;
-  invoiceItem?: BillingInvoiceItem;
+  isTransactionBillingActivated?: boolean;
   lastUpdate?: Date;
+  stop?: BillingDataTransactionStop;
 }
 
 export interface BillingDataTransactionStart {
-  cancelTransaction?: boolean;
+  isTransactionBillingActivated: boolean;
 }
 
 export interface BillingDataTransactionUpdate {
-  cancelTransaction?: boolean;
+  isTransactionBillingActivated: boolean;
 }
 
 export enum BillingStatus {

--- a/src/types/Setting.ts
+++ b/src/types/Setting.ts
@@ -237,6 +237,7 @@ export interface BillingSettings extends Setting {
 }
 
 export interface BillingSetting {
+  isTransactionBillingActivated: boolean;
   immediateBillingAllowed: boolean;
   periodicBillingAllowed: boolean;
   taxID: string;

--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -56,7 +56,7 @@ class TestData {
     assert(!!tenantId, 'Tenant ID cannot be null');
     billingSettings.stripe.secretKey = await Cypher.encrypt(tenantId, billingSettings.stripe.secretKey);
     const billingImpl = StripeBillingIntegration.getInstance(tenantId, billingSettings);
-    expect(billingImpl).to.not.be.null;
+    assert(billingImpl, 'Billing implementation should not be null');
     return billingImpl;
   }
 
@@ -67,12 +67,13 @@ class TestData {
     billingSettings.stripe.secretKey = await Cypher.encrypt(tenantId, 'sk_test_' + 'invalid_credentials');
     await this.saveBillingSettings(billingSettings);
     const billingImpl = StripeBillingIntegration.getInstance(tenantId, billingSettings);
-    expect(billingImpl).to.not.be.null;
+    assert(billingImpl, 'Billing implementation should not be null');
     return billingImpl;
   }
 
-  public getLocalSettings(immediateBilling: boolean): BillingSettings {
+  public getLocalSettings(immediateBillingAllowed: boolean): BillingSettings {
     const billingProperties = {
+      isTransactionBillingActivated: config.get('billing.isTransactionBillingActivated'),
       immediateBillingAllowed: config.get('billing.immediateBillingAllowed'),
       periodicBillingAllowed: config.get('billing.periodicBillingAllowed'),
       taxID: config.get('billing.taxID')
@@ -89,11 +90,11 @@ class TestData {
       stripe: stripeProperties,
     };
 
-    // ---------------------------------------------------------
+    // -----------------------------------------------------------------
     // Our test needs the immediate billing to be switched off!
     // Because we want to check the DRAFT state of the invoice
-    settings.billing.immediateBillingAllowed = immediateBilling;
-    // ---------------------------------------------------------
+    settings.billing.immediateBillingAllowed = immediateBillingAllowed;
+    // -----------------------------------------------------------------
     return settings;
   }
 
@@ -483,6 +484,7 @@ describe('Billing Service', function() {
         } as User;
         fakeUser.issuer = true;
         testData.billingImpl = await testData.setBillingSystemInvalidCredentials();
+        assert(testData.billingImpl, 'Billing implementation should not be null');
         await testData.userService.createEntity(
           testData.userService.userApi,
           fakeUser
@@ -504,6 +506,7 @@ describe('Billing Service', function() {
         assert(!!testData.userService, 'User service cannot be null');
         // Force INVALID STRIPE credentials
         testData.billingImpl = await testData.setBillingSystemInvalidCredentials();
+        assert(testData.billingImpl, 'Billing implementation should not be null');
       });
 
       after(async () => {

--- a/test/api/context/BillingContext.ts
+++ b/test/api/context/BillingContext.ts
@@ -21,6 +21,7 @@ export default class BillingContext {
 
   private static getBillingSettings(): BillingSettings {
     const billingProperties = {
+      isTransactionBillingActivated: config.get('billing.isTransactionBillingActivated'),
       immediateBillingAllowed: config.get('billing.immediateBillingAllowed'),
       periodicBillingAllowed: config.get('billing.periodicBillingAllowed'),
       taxID: config.get('billing.taxID')

--- a/test/api/context/ContextDefinition.ts
+++ b/test/api/context/ContextDefinition.ts
@@ -179,6 +179,7 @@ export default class ContextDefinition {
         content: {
           type: BillingSettingsType.STRIPE,
           billing: {
+            isTransactionBillingActivated: true,
             immediateBillingAllowed: true,
             periodicBillingAllowed: true,
             taxID: ''
@@ -307,6 +308,7 @@ export default class ContextDefinition {
         content: {
           type: BillingSettingsType.STRIPE,
           billing: {
+            isTransactionBillingActivated: true,
             immediateBillingAllowed: true,
             periodicBillingAllowed: true,
             taxID: ''

--- a/test/config-template.json
+++ b/test/config-template.json
@@ -51,6 +51,7 @@
     "debug": false
   },
   "billing": {
+    "isTransactionBillingActivated": true,
     "immediateBillingAllowed": true,
     "periodicBillingAllowed": true,
     "taxID": ""

--- a/test/config.js
+++ b/test/config.js
@@ -252,15 +252,20 @@ const config = convict({
     }
   },
   billing: {
+    isTransactionBillingActivated: {
+      doc: 'Activates the billing of transactions feature',
+      format: Boolean,
+      default: true
+    },
     immediateBillingAllowed: {
       doc: 'Allow immediate billing',
       format: Boolean,
-      default: ''
+      default: true
     },
     periodicBillingAllowed: {
       doc: 'Allow periodic billing',
       format: Boolean,
-      default: ''
+      default: false
     },
     taxID: {
       doc: 'taxes to apply by default',


### PR DESCRIPTION
The billing settings have been changed to allow entering the stripe connection settings without activating the billing feature.

**isTransactionBillingActivated**
- This new property can be used to switch ON/OFF the billing of transactions.
- This property should only be set to true when the settings are consistent (this will be done later)

This information is used on start transaction and stored in the transaction billing data as the **withBillingActive** flag.
This flag is propagated until the stop transaction.

**Transaction Billing Data Example:**

![image](https://user-images.githubusercontent.com/26900551/115014815-1abf2080-9eb3-11eb-9e90-3d4822e1fbb8.png)




