### PR TITLE
OCPPUtils.ts: Avoid to loop over empty OCPPMeterValue array.

### DIFF
--- a/src/async-task/tasks/TagsImportAsyncTask.ts
+++ b/src/async-task/tasks/TagsImportAsyncTask.ts
@@ -98,7 +98,7 @@ export default class TagsImportAsyncTask extends AbstractAsyncTask {
             }
           }
           // Log
-          if (importedTags.result.length > 0 && (result.inError + result.inSuccess) > 0) {
+          if (!Utils.isEmptyArray(importedTags.result) && (result.inError + result.inSuccess) > 0) {
             const intermediateDurationSecs = Math.round((new Date().getTime() - startTime) / 1000);
             await Logging.logDebug({
               tenantID: tenant.id,

--- a/src/authorization/Authorizations.ts
+++ b/src/authorization/Authorizations.ts
@@ -96,7 +96,7 @@ export default class Authorizations {
     if (this.isAdmin(loggedUser)) {
       return requestedSites;
     }
-    if (!requestedSites || requestedSites.length === 0) {
+    if (Utils.isEmptyArray(requestedSites)) {
       return loggedUser.sites;
     }
     return requestedSites.filter((site) => loggedUser.sites.includes(site));
@@ -116,7 +116,7 @@ export default class Authorizations {
     for (const siteID of loggedUser.sitesOwner) {
       sites.add(siteID);
     }
-    if (!requestedSites || requestedSites.length === 0) {
+    if (Utils.isEmptyArray(requestedSites)) {
       return [...sites];
     }
     return requestedSites.filter((site) => sites.has(site));
@@ -741,11 +741,11 @@ export default class Authorizations {
   }
 
   public static isSiteAdmin(user: UserToken): boolean {
-    return user.role === UserRole.BASIC && user.sitesAdmin && user.sitesAdmin.length > 0;
+    return user.role === UserRole.BASIC && !Utils.isEmptyArray(user.sitesAdmin);
   }
 
   public static isSiteOwner(user: UserToken): boolean {
-    return user.sitesOwner && user.sitesOwner.length > 0;
+    return !Utils.isEmptyArray(user.sitesOwner);
   }
 
   public static isBasic(user: UserToken | User): boolean {

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -40,8 +40,8 @@ export default abstract class BillingIntegration {
     };
     if (FeatureToggles.isFeatureActive(Feature.BILLING_SYNC_USERS)) {
       // Sync e-Mobility Users with no billing data
-      const users: User[] = await this._getUsersWithNoBillingData();
-      if (users.length > 0) {
+      const users = await this._getUsersWithNoBillingData();
+      if (!Utils.isEmptyArray(users)) {
         // Process them
         await Logging.logInfo({
           tenantID: this.tenantID,

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -818,7 +818,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       status: BillingInvoiceStatus.DRAFT,
       limit: 1
     });
-    return (list.data.length > 0) ? list.data[0] : null;
+    return !Utils.isEmptyArray((list.data)) ? list.data[0] : null;
   }
 
   public async billTransaction(transaction: Transaction): Promise<BillingDataTransactionStop> {
@@ -1005,7 +1005,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       customer: user.billingData.customerID,
       status: BillingInvoiceStatus.OPEN,
     });
-    if (list && list.data && list.data.length > 0) {
+    if (list && !Utils.isEmptyArray(list.data)) {
       await Logging.logError({
         tenantID: this.tenantID,
         action: ServerAction.USER_DELETE,
@@ -1020,7 +1020,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       customer: user.billingData.customerID,
       status: BillingInvoiceStatus.DRAFT,
     });
-    if (list && list.data && list.data.length > 0) {
+    if (list && !Utils.isEmptyArray(list.data)) {
       await Logging.logError({
         tenantID: this.tenantID,
         action: ServerAction.USER_DELETE,

--- a/src/integration/charging-station-vendor/ChargingStationVendorIntegration.ts
+++ b/src/integration/charging-station-vendor/ChargingStationVendorIntegration.ts
@@ -407,7 +407,7 @@ export default abstract class ChargingStationVendorIntegration {
           chargingProfile.connectorID === 0 &&
           chargingProfile.profile.chargingProfilePurpose === ChargingProfilePurposeType.TX_DEFAULT_PROFILE
         );
-        if (txDefaultChargingProfiles.length === 0) {
+        if (Utils.isEmptyArray(txDefaultChargingProfiles)) {
           txDefaultChargingProfiles = chargingProfiles.filter((chargingProfile) =>
             chargingProfile.connectorID === connectorID &&
             chargingProfile.profile.chargingProfilePurpose === ChargingProfilePurposeType.TX_DEFAULT_PROFILE

--- a/src/migration/tasks/AddUserInTransactionsTask.ts
+++ b/src/migration/tasks/AddUserInTransactionsTask.ts
@@ -25,7 +25,7 @@ export default class AddUserInTransactionsTask extends MigrationTask {
       .aggregate([
         { $match: { userID: null } }
       ]).toArray();
-    if (transactionsMDB.length > 0) {
+    if (!Utils.isEmptyArray(transactionsMDB)) {
       await Logging.logInfo({
         tenantID: Constants.DEFAULT_TENANT,
         action: ServerAction.MIGRATION,

--- a/src/migration/tasks/CleanupMeterValuesTask.ts
+++ b/src/migration/tasks/CleanupMeterValuesTask.ts
@@ -52,7 +52,7 @@ export default class CleanupMeterValuesTask extends MigrationTask {
         .findOneAndDelete({ '_id': meterValueMDB._id });
     }
     // Log
-    if (meterValuesMDB.length > 0) {
+    if (!Utils.isEmptyArray(meterValuesMDB)) {
       await Logging.logWarning({
         tenantID: Constants.DEFAULT_TENANT,
         action: ServerAction.MIGRATION,

--- a/src/migration/tasks/RecomputeAllTransactionsConsumptionsTask.ts
+++ b/src/migration/tasks/RecomputeAllTransactionsConsumptionsTask.ts
@@ -42,7 +42,7 @@ export default class RecomputeAllTransactionsConsumptionsTask extends MigrationT
           $project: { '_id': 1 }
         }
       ]).toArray();
-    if (transactionsMDB.length > 0) {
+    if (!Utils.isEmptyArray(transactionsMDB)) {
       void Logging.logInfo({
         tenantID: Constants.DEFAULT_TENANT,
         action: ServerAction.MIGRATION,

--- a/src/migration/tasks/RecomputeAllTransactionsWithSimplePricingTask.ts
+++ b/src/migration/tasks/RecomputeAllTransactionsWithSimplePricingTask.ts
@@ -47,7 +47,7 @@ export default class RecomputeAllTransactionsWithSimplePricingTask extends Migra
           $project: { '_id': 1, 'migrationFlag': 1 }
         }
       ]).toArray();
-    if (transactionsMDB.length > 0) {
+    if (Utils.isEmptyArray(transactionsMDB)) {
       let message = `${transactionsMDB.length} Transaction(s) are going to be recomputed in Tenant ${Utils.buildTenantName(tenant)}...`;
       await Logging.logInfo({
         tenantID: Constants.DEFAULT_TENANT,

--- a/src/migration/tasks/RecomputeAllTransactionsWithSimplePricingTask.ts
+++ b/src/migration/tasks/RecomputeAllTransactionsWithSimplePricingTask.ts
@@ -47,7 +47,7 @@ export default class RecomputeAllTransactionsWithSimplePricingTask extends Migra
           $project: { '_id': 1, 'migrationFlag': 1 }
         }
       ]).toArray();
-    if (Utils.isEmptyArray(transactionsMDB)) {
+    if (!Utils.isEmptyArray(transactionsMDB)) {
       let message = `${transactionsMDB.length} Transaction(s) are going to be recomputed in Tenant ${Utils.buildTenantName(tenant)}...`;
       await Logging.logInfo({
         tenantID: Constants.DEFAULT_TENANT,

--- a/src/migration/tasks/UpdateConsumptionsToObjectIDsTask.ts
+++ b/src/migration/tasks/UpdateConsumptionsToObjectIDsTask.ts
@@ -1,4 +1,5 @@
 import Constants from '../../utils/Constants';
+import Consumption from '../../types/Consumption';
 import Logging from '../../utils/Logging';
 import MigrationTask from '../MigrationTask';
 import { ServerAction } from '../../types/Server';
@@ -36,7 +37,7 @@ export default class UpdateConsumptionsToObjectIDsTask extends MigrationTask {
     let consumptionsMDB;
     do {
       // Read
-      consumptionsMDB = await global.database.getCollection<any>(tenant.id, 'consumptions')
+      consumptionsMDB = await global.database.getCollection<Consumption>(tenant.id, 'consumptions')
         .aggregate(aggregation).toArray();
       // Check and Update whole consumption
       for (const consumptionMDB of consumptionsMDB) {
@@ -68,7 +69,7 @@ export default class UpdateConsumptionsToObjectIDsTask extends MigrationTask {
           updated += result.modifiedCount;
         }
       }
-    } while (consumptionsMDB.length > 0);
+    } while (!Utils.isEmptyArray(consumptionsMDB));
     // Log
     if (updated > 0) {
       await Logging.logDebug({

--- a/src/notification/NotificationHandler.ts
+++ b/src/notification/NotificationHandler.ts
@@ -369,7 +369,7 @@ export default class NotificationHandler {
       adminSourceData.tenantLogoURL = tenant.logo;
       // Get the admin
       const adminUsers = await NotificationHandler.getAdminUsers(tenantID, 'sendAdminAccountVerificationNotification');
-      if (adminUsers && adminUsers.length > 0) {
+      if (!Utils.isEmptyArray(adminUsers)) {
         // For each Sources
         for (const notificationSource of NotificationHandler.notificationSources) {
           // Active?
@@ -564,7 +564,7 @@ export default class NotificationHandler {
       sourceData.tenantLogoURL = tenant.logo;
       // Enrich with admins
       const adminUsers = await NotificationHandler.getAdminUsers(tenantID, 'sendSmtpError');
-      if (adminUsers && adminUsers.length > 0) {
+      if (!Utils.isEmptyArray(adminUsers)) {
         // For each Sources
         for (const notificationSource of NotificationHandler.notificationSources) {
           // Active?

--- a/src/scheduler/tasks/ocpi/OCPIPushCdrsTask.ts
+++ b/src/scheduler/tasks/ocpi/OCPIPushCdrsTask.ts
@@ -38,7 +38,7 @@ export default class OCPIPushCdrsTask extends SchedulerTask {
                   $project: { '_id': 1 }
                 }
               ]).toArray();
-            if (transactionsMDB.length > 0) {
+            if (!Utils.isEmptyArray(transactionsMDB)) {
               await Logging.logInfo({
                 tenantID: tenant.id,
                 action: ServerAction.OCPI_PUSH_CDRS,

--- a/src/server/ExpressUtils.ts
+++ b/src/server/ExpressUtils.ts
@@ -105,7 +105,7 @@ export default class ExpressUtils {
       // Intermediate cert?
       if (serverConfig.sslCa) {
         // Array?
-        if (Array.isArray(serverConfig.sslCa)) {
+        if (!Utils.isEmptyArray(serverConfig.sslCa)) {
           options.ca = [];
           // Add all
           for (let i = 0; i < serverConfig.sslCa.length; i++) {

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -724,7 +724,7 @@ export default class OCPPUtils {
       attribute: Constants.OCPP_ENERGY_ACTIVE_IMPORT_REGISTER_ATTRIBUTE
     });
     // Add SignedData
-    if (!Utils.isEmptyArray(stopTransaction.transactionData as OCPPMeterValue[])) {
+    if (!Utils.isEmptyArray(stopTransaction.transactionData)) {
       for (const meterValue of stopTransaction.transactionData as OCPPMeterValue[]) {
         for (const sampledValue of meterValue.sampledValue) {
           if (sampledValue.format === OCPPValueFormat.SIGNED_DATA) {

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -724,8 +724,8 @@ export default class OCPPUtils {
       attribute: Constants.OCPP_ENERGY_ACTIVE_IMPORT_REGISTER_ATTRIBUTE
     });
     // Add SignedData
-    if (Array.isArray(stopTransaction.transactionData)) {
-      for (const meterValue of stopTransaction.transactionData) {
+    if (!Utils.isEmptyArray(stopTransaction.transactionData as OCPPMeterValue[])) {
+      for (const meterValue of stopTransaction.transactionData as OCPPMeterValue[]) {
         for (const sampledValue of meterValue.sampledValue) {
           if (sampledValue.format === OCPPValueFormat.SIGNED_DATA) {
             let attribute: OCPPAttribute;

--- a/src/storage/mongodb/TransactionStorage.ts
+++ b/src/storage/mongodb/TransactionStorage.ts
@@ -251,7 +251,7 @@ export default class TransactionStorage {
       .limit(1)
       .toArray();
     // Found?
-    if (!firstTransactionsMDB || firstTransactionsMDB.length === 0) {
+    if (Utils.isEmptyArray(firstTransactionsMDB)) {
       return null;
     }
     const transactionYears = [];

--- a/src/storage/mongodb/UserStorage.ts
+++ b/src/storage/mongodb/UserStorage.ts
@@ -46,7 +46,7 @@ export default class UserStorage {
       .limit(1)
       .toArray();
     // Found?
-    if (eulasMDB && eulasMDB.length > 0) {
+    if (!Utils.isEmptyArray(eulasMDB)) {
       // Get
       const eulaMDB = eulasMDB[0];
       // Check if eula has changed
@@ -146,7 +146,7 @@ export default class UserStorage {
     // User provided?
     if (userID) {
       // At least one Site
-      if (siteIDs && siteIDs.length > 0) {
+      if (!Utils.isEmptyArray(siteIDs)) {
         // Create the lis
         await global.database.getCollection<User>(tenantID, 'siteusers').deleteMany({
           'userID': Utils.convertToObjectID(userID),
@@ -164,7 +164,7 @@ export default class UserStorage {
     // Check Tenant
     await DatabaseUtils.checkTenant(tenantID);
     // At least one Site
-    if (siteIDs && siteIDs.length > 0) {
+    if (!Utils.isEmptyArray(siteIDs)) {
       const siteUsersMDB = [];
       // Create the list
       for (const siteID of siteIDs) {
@@ -586,7 +586,7 @@ export default class UserStorage {
       filters['billingData.customerID'] = params.billingUserID;
     }
     // Status (Previously getUsersInError)
-    if (params.statuses && params.statuses.length > 0) {
+    if (!Utils.isEmptyArray(params.statuses)) {
       filters.status = { $in: params.statuses };
     }
     // Notifications
@@ -670,7 +670,7 @@ export default class UserStorage {
       // Return only the count
       await Logging.traceEnd(tenantID, MODULE_NAME, 'getUsers', uniqueTimerID, usersCountMDB);
       return {
-        count: (usersCountMDB.length > 0 ? usersCountMDB[0].count : 0),
+        count: (!Utils.isEmptyArray(usersCountMDB) ? usersCountMDB[0].count : 0),
         result: []
       };
     }
@@ -707,7 +707,7 @@ export default class UserStorage {
     await Logging.traceEnd(tenantID, MODULE_NAME, 'getUsers', uniqueTimerID, usersMDB);
     // Ok
     return {
-      count: (usersCountMDB.length > 0 ?
+      count: (!Utils.isEmptyArray(usersCountMDB) ?
         (usersCountMDB[0].count === Constants.DB_RECORD_COUNT_CEIL ? -1 : usersCountMDB[0].count) : 0),
       result: usersMDB
     };
@@ -771,7 +771,7 @@ export default class UserStorage {
       // Return only the count
       await Logging.traceEnd(tenantID, MODULE_NAME, 'getImportedUsers', uniqueTimerID, usersImportCountMDB);
       return {
-        count: (usersImportCountMDB.length > 0 ? usersImportCountMDB[0].count : 0),
+        count: (!Utils.isEmptyArray(usersImportCountMDB) ? usersImportCountMDB[0].count : 0),
         result: []
       };
     }
@@ -810,7 +810,7 @@ export default class UserStorage {
     await Logging.traceEnd(tenantID, MODULE_NAME, 'getUsersImport', uniqueTimerID, usersImportMDB);
     // Ok
     return {
-      count: (usersImportCountMDB.length > 0 ?
+      count: (!Utils.isEmptyArray(usersImportCountMDB) ?
         (usersImportCountMDB[0].count === Constants.DB_RECORD_COUNT_CEIL ? -1 : usersImportCountMDB[0].count) : 0),
       result: usersImportMDB
     };
@@ -996,7 +996,7 @@ export default class UserStorage {
     if (dbParams.onlyRecordCount) {
       await Logging.traceEnd(tenantID, MODULE_NAME, 'getUserSites', uniqueTimerID, sitesCountMDB);
       return {
-        count: (sitesCountMDB.length > 0 ? sitesCountMDB[0].count : 0),
+        count: (!Utils.isEmptyArray(sitesCountMDB) ? sitesCountMDB[0].count : 0),
         result: []
       };
     }
@@ -1033,7 +1033,7 @@ export default class UserStorage {
     await Logging.traceEnd(tenantID, MODULE_NAME, 'getUserSites', uniqueTimerID, siteUsersMDB);
     // Ok
     return {
-      count: (sitesCountMDB.length > 0 ?
+      count: (!Utils.isEmptyArray(sitesCountMDB) ?
         (sitesCountMDB[0].count === Constants.DB_RECORD_COUNT_CEIL ? -1 : sitesCountMDB[0].count) : 0),
       result: siteUsersMDB
     };

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -833,7 +833,7 @@ export default class Utils {
     return amperageLimit;
   }
 
-  public static isEmptyArray(array: any[]): boolean {
+  public static isEmptyArray(array: any): boolean {
     if (!array) {
       return true;
     }

--- a/test/api/context/TenantContext.ts
+++ b/test/api/context/TenantContext.ts
@@ -262,7 +262,7 @@ export default class TenantContext {
 
   async createSiteArea(site, chargingStations, siteArea) {
     siteArea.siteID = (site && site.id ? (!siteArea.siteID || siteArea.siteID !== site.id ? site.id : siteArea.siteID) : null);
-    siteArea.chargeBoxIDs = (Array.isArray(chargingStations) && (!siteArea.chargeBoxIDs || siteArea.chargeBoxIDs.length === 0) ? chargingStations.map((chargingStation) => chargingStation.id) : []);
+    siteArea.chargeBoxIDs = (Array.isArray(chargingStations) && Utils.isEmptyArray(siteArea.chargeBoxIDs) ? chargingStations.map((chargingStation) => chargingStation.id) : []);
     const createdSiteArea = await this.centralAdminServerService.createEntity(this.centralAdminServerService.siteAreaApi, siteArea);
     this.context.createdSiteAreas.push(new SiteAreaContext(createdSiteArea, this));
     return createdSiteArea;


### PR DESCRIPTION
+ Allow to use isEmptyArray on more object. And start doing it a bit.

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>