### PR TITLE
Billing - fix transaction billing errors

### DIFF
--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -348,7 +348,9 @@ export default class OCPPUtils {
             // Delegate
             await billingImpl.updateTransaction(transaction);
             // Update
-            transaction.billingData.lastUpdate = new Date();
+            if (transaction.billingData) {
+              transaction.billingData.lastUpdate = new Date();
+            }
           } catch (error) {
             await Logging.logError({
               tenantID: tenantID,
@@ -367,8 +369,10 @@ export default class OCPPUtils {
             // Delegate
             const billingDataStop: BillingDataTransactionStop = await billingImpl.stopTransaction(transaction);
             // Update
-            transaction.billingData.stop = billingDataStop;
-            transaction.billingData.lastUpdate = new Date();
+            if (transaction.billingData) {
+              transaction.billingData.stop = billingDataStop;
+              transaction.billingData.lastUpdate = new Date();
+            }
           } catch (error) {
             await Logging.logError({
               tenantID: tenantID,


### PR DESCRIPTION
Minor change to avoid generating errors when Billing Features are OFF.

- Actually the problem only occured on Transactions that were started before enabling the billing module. So, this was not supposed to happen.