### PR TITLE
Add a UUID to the WSConnection ID:

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Other protocols, like the ISO 15118, or OCPP version 2.0 will also be supported 
 
 #### Configuration
 
-In 'src/assets' folder there are two templates already provided named **config-template-http.json** for HTTP and **config-template-https.json** for HTTPS.
+In **src/assets** folder there are two templates already provided named **config-template-http.json** for HTTP and **config-template-https.json** for HTTPS.
 
 Choose one and rename it to **config.json**.
 
@@ -263,10 +263,10 @@ To set the end point, fill the following information in the **config.json** file
   }
 ```
 
-In order to properly call the REST endpoints, both ev-server and client must reference a Google reCaptcha key. You can refer to this link https://www.google.com/recaptcha/admin/create, then copy the server key in config.json file, in section CentralSystemRestService:
+In order to properly call the REST endpoints, both ev-server and clients (ev-dashboard, ev-mobile, etc.) must reference a Google reCaptcha key. You can refer to this link https://www.google.com/recaptcha/admin/create, then copy the server key in config.json file, in section CentralSystemRestService:
 
     ...
-    "captchaSecretKey":"<GOOGLE_RECAPTCHA_KEY_SERVER>"
+    "captchaSecretKey": "<GOOGLE_RECAPTCHA_KEY_SERVER>"
     ...
 
 ### Central Service Server (CSS) > Database
@@ -285,7 +285,6 @@ Database connection info:
     "port": 27017,
     "user": "evse-user",
     "password": "YourPassword",
-    "schema": "evse",
     "database" : "evse"
   }
 ```

--- a/src/client/ocpp/json/JsonChargingStationClient.ts
+++ b/src/client/ocpp/json/JsonChargingStationClient.ts
@@ -11,12 +11,8 @@ import Utils from '../../../utils/Utils';
 const MODULE_NAME = 'JsonChargingStationClient';
 
 export default class JsonChargingStationClient extends ChargingStationClient {
-  public tagID: string;
-  public type: string;
-  public key: string;
   private chargingStationID: string;
   private tenantID: string;
-
   private wsConnection: JsonWSConnection;
 
   constructor(wsConnection: JsonWSConnection, tenantID: string, chargingStationID: string) {

--- a/src/client/ocpp/soap/SoapChargingStationClient.ts
+++ b/src/client/ocpp/soap/SoapChargingStationClient.ts
@@ -13,16 +13,6 @@ import { soap } from 'strong-soap';
 const MODULE_NAME = 'SoapChargingStationClient';
 
 export default class SoapChargingStationClient extends ChargingStationClient {
-  public transactionId: number;
-  public error: any;
-  public result: any;
-  public envelope: any;
-  public tagID: string;
-  public connectorID: any;
-  public type: any;
-  // pragma public keys: any;
-  // public keys: any[];
-  // public value: any;
   private chargingStation: ChargingStation;
   private tenantID: string;
   private client: any;

--- a/src/server/ocpp/json/JsonCentralSystemServer.ts
+++ b/src/server/ocpp/json/JsonCentralSystemServer.ts
@@ -45,7 +45,7 @@ export default class JsonCentralSystemServer extends CentralSystemServer {
 
   public getChargingStationClient(tenantID: string, chargingStationID: string): ChargingStationClient {
     // Build ID
-    const id = `${tenantID}~${chargingStationID}}`;
+    const id = `${tenantID}~${chargingStationID}`;
     // Get the Json Web Socket
     let jsonWebSocket: JsonWSConnection;
     for (const [wsClientID, wsClient] of this.jsonChargingStationClients) {

--- a/src/server/ocpp/json/JsonWSConnection.ts
+++ b/src/server/ocpp/json/JsonWSConnection.ts
@@ -33,7 +33,7 @@ export default class JsonWSConnection extends WSConnection {
       // OCPP 1.6?
       case WSServerProtocol.OCPP16:
         // Create the Json Client
-        this.chargingStationClient = new JsonChargingStationClient(this, this.tenantID, this.chargingStationID);
+        this.chargingStationClient = new JsonChargingStationClient(this, this.getTenantID(), this.getChargingStationID());
         // Create the Json Server Service
         this.chargingStationService = new JsonChargingStationService();
         break;

--- a/src/server/ocpp/json/WSConnection.ts
+++ b/src/server/ocpp/json/WSConnection.ts
@@ -19,27 +19,23 @@ import http from 'http';
 const MODULE_NAME = 'WSConnection';
 
 export default abstract class WSConnection {
-  public code: string;
-  public message: string;
-  public details: string;
   protected initialized: boolean;
   protected wsServer: JsonCentralSystemServer;
-  protected readonly chargingStationID: string;
-  protected readonly tenantID: string;
+  private readonly uuid: string;
+  private readonly chargingStationID: string;
+  private readonly tenantID: string;
   private readonly token: string;
   private readonly url: string;
   private readonly clientIP: string | string[];
   private readonly wsConnection: WebSocket;
-  private req: http.IncomingMessage;
   private requests: { [id: string]: OCPPRequest };
-  private tenantIsValid: boolean;
+  private validTenant: boolean;
 
   constructor(wsConnection: WebSocket, req: http.IncomingMessage, wsServer: JsonCentralSystemServer) {
     // Init
     this.url = req.url.trim().replace(/\b(\?|&).*/, ''); // Filter trailing URL parameters
     this.clientIP = Utils.getRequestIP(req);
     this.wsConnection = wsConnection;
-    this.req = req;
     this.initialized = false;
     this.wsServer = wsServer;
     Logging.logDebug({
@@ -49,7 +45,7 @@ export default abstract class WSConnection {
       message: `WS connection opening attempts with URL: '${req.url}'`,
     });
     // Default
-    this.tenantIsValid = false;
+    this.validTenant = false;
     this.requests = {};
     // Check URL: remove starting and trailing '/'
     if (this.url.endsWith('/')) {
@@ -80,6 +76,7 @@ export default abstract class WSConnection {
         message: `The URL '${req.url}' is invalid (/(OCPPxx|REST)/TENANT_ID/CHARGEBOX_ID)`
       });
     }
+    this.uuid = Utils.generateUUID();
     let logMsg = `Unknown type WS connection attempts with URL: '${req.url}'`;
     let action: ServerAction = ServerAction.WS_CONNECTION_OPENED;
     if (req.url.startsWith('/REST')) {
@@ -125,7 +122,7 @@ export default abstract class WSConnection {
     try {
       // Check Tenant?
       await DatabaseUtils.checkTenant(this.tenantID);
-      this.tenantIsValid = true;
+      this.validTenant = true;
       // Cloud Foundry?
       if (Configuration.isCloudFoundry()) {
         // Yes: Save the CF App and Instance ID to call the Charging Station from the Rest server
@@ -259,10 +256,6 @@ export default abstract class WSConnection {
     return this.wsConnection;
   }
 
-  public getWSServer(): JsonCentralSystemServer {
-    return this.wsServer;
-  }
-
   public getURL(): string {
     return this.url;
   }
@@ -362,11 +355,11 @@ export default abstract class WSConnection {
   }
 
   public getID(): string {
-    return `${this.getTenantID()}~${this.getChargingStationID()}}`;
+    return `${this.getTenantID()}~${this.getChargingStationID()}~${this.uuid}`;
   }
 
   public isTenantValid(): boolean {
-    return this.tenantIsValid;
+    return this.validTenant;
   }
 
   public isWSConnectionOpen(): boolean {

--- a/src/server/ocpp/json/WSServer.ts
+++ b/src/server/ocpp/json/WSServer.ts
@@ -35,7 +35,7 @@ export default class WSServer extends WebSocket.Server {
 
   public start(): void {
     // Make the server listen
-    ServerUtils.startHttpServer(this.serverConfig, this.httpServer, MODULE_NAME, this.serverName,);
+    ServerUtils.startHttpServer(this.serverConfig, this.httpServer, MODULE_NAME, this.serverName);
   }
 }
 

--- a/src/server/ocpp/soap/SoapCentralSystemServer.ts
+++ b/src/server/ocpp/soap/SoapCentralSystemServer.ts
@@ -39,7 +39,7 @@ export default class SoapCentralSystemServer extends CentralSystemServer {
   start(): void {
     // Make it global for SOAP Services
     global.centralSystemSoapServer = this;
-    ServerUtils.startHttpServer(this.centralSystemConfig, this.httpServer, MODULE_NAME, 'OCPP-S',);
+    ServerUtils.startHttpServer(this.centralSystemConfig, this.httpServer, MODULE_NAME, 'OCPP-S');
     // Create Soap Servers
     // OCPP 1.2 -----------------------------------------
     const soapServer12 = soap.listen(this.httpServer, `/${Utils.getOCPPServerVersionURLPath(OCPPVersion.VERSION_12)}`, centralSystemService12, this.readWsdl('OCPPCentralSystemService12.wsdl'));

--- a/src/server/uWsUtils.ts
+++ b/src/server/uWsUtils.ts
@@ -25,7 +25,7 @@ export class uWsUtils {
   }
 
   public static startServer(serverConfig: CentralSystemServerConfiguration, app: TemplatedApp,
-      serverName: string, serverModuleName: string, listenCb?: () => void, listen = true): void {
+      serverName: string, serverModuleName: string, listenCb?: () => void): void {
     let cb: () => void;
     if (listenCb && typeof listenCb === 'function') {
       cb = listenCb;
@@ -36,11 +36,11 @@ export class uWsUtils {
     }
 
     // Listen
-    if (serverConfig.host && serverConfig.port && listen) {
+    if (serverConfig.host && serverConfig.port) {
       app.listen(serverConfig.host, serverConfig.port, cb);
-    } else if (!serverConfig.host && serverConfig.port && listen) {
+    } else if (!serverConfig.host && serverConfig.port) {
       app.listen(serverConfig.port, cb);
-    } else if (listen) {
+    } else {
       // eslint-disable-next-line no-console
       console.log(`Fail to start ${serverName} Server listening ${cluster.isWorker ? 'in worker ' + cluster.worker.id.toString() : 'in master'}, missing required port configuration`);
     }

--- a/test/api/ocpp/json/OCPPJsonService16.ts
+++ b/test/api/ocpp/json/OCPPJsonService16.ts
@@ -1,6 +1,6 @@
 import { OCPP15MeterValuesRequest, OCPPAuthorizeRequest, OCPPAuthorizeResponse, OCPPBootNotificationRequest, OCPPBootNotificationResponse, OCPPDataTransferRequest, OCPPDataTransferResponse, OCPPDiagnosticsStatusNotificationRequest, OCPPDiagnosticsStatusNotificationResponse, OCPPFirmwareStatusNotificationRequest, OCPPFirmwareStatusNotificationResponse, OCPPHeartbeatRequest, OCPPHeartbeatResponse, OCPPMeterValuesRequest, OCPPMeterValuesResponse, OCPPStartTransactionRequest, OCPPStartTransactionResponse, OCPPStatusNotificationRequest, OCPPStatusNotificationResponse, OCPPStopTransactionRequest, OCPPStopTransactionResponse, OCPPVersion } from '../../../../src/types/ocpp/OCPPServer';
 import { OCPPIncomingRequest, OCPPMessageType } from '../../../../src/types/ocpp/OCPPCommon';
-import { ServerAction, ServerProtocol, WSServerProtocol } from '../../../../src/types/Server';
+import { ServerAction, WSServerProtocol } from '../../../../src/types/Server';
 
 import OCPPService from '../OCPPService';
 import Utils from '../../../../src/utils/Utils';


### PR DESCRIPTION
Allow charging stations to open two connections with the OCPP-J backend
that will not be identified as the same in the server connection cache Map.
That will close race condition at remove that might occurs in that
case:

    Connection one                  | Connection two
    CLOSING                         | OPEN
     --> CLOSED                     |
                           --> removed from cache

Should close the issue at remote commands failure for ChargeX. 

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>