### PR TITLE
Dedupe MeterValues in enum + cleanups

### DIFF
--- a/src/server/ocpi/ocpi-services-impl/ocpi-2.1.1/OCPIUtilsService.ts
+++ b/src/server/ocpi/ocpi-services-impl/ocpi-2.1.1/OCPIUtilsService.ts
@@ -170,7 +170,7 @@ export default class OCPIUtilsService {
   }
 
   public static async convertSite2Location(tenant: Tenant, site: Site,
-      options: OCPILocationOptions, withChargingStations): Promise<OCPILocation> {
+      options: OCPILocationOptions, withChargingStations: boolean): Promise<OCPILocation> {
     // Build object
     return {
       id: site.id,

--- a/src/server/ocpp/json/services/JsonChargingStationService.ts
+++ b/src/server/ocpp/json/services/JsonChargingStationService.ts
@@ -45,7 +45,7 @@ export default class JsonChargingStationService {
 
   public async handleMeterValues(headers: OCPPHeader, payload: OCPPMeterValuesRequest): Promise<OCPPMeterValuesResponse> {
     // Forward
-    await this.handle(ServerAction.METERVALUES, headers, payload);
+    await this.handle(ServerAction.METER_VALUES, headers, payload);
     // Return the response
     return {};
   }

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -2233,12 +2233,12 @@ export default class OCPPUtils {
   }
 
   private static async setConnectorPhaseAssignment(tenantID: string, chargingStation: ChargingStation, connector: Connector, nrOfPhases?: number): Promise<void> {
-    const numberOfPhases = nrOfPhases ?? Utils.getNumberOfConnectedPhases(chargingStation, null, connector.connectorId);
+    const csNumberOfPhases = nrOfPhases ?? Utils.getNumberOfConnectedPhases(chargingStation, null, connector.connectorId);
     if (chargingStation.siteAreaID) {
       const siteArea = await SiteAreaStorage.getSiteArea(tenantID, chargingStation.siteAreaID);
       // Phase Assignment to Grid has to be handled only for Site Area with 3 phases
       if (siteArea.numberOfPhases === 3) {
-        switch (numberOfPhases) {
+        switch (csNumberOfPhases) {
           // Tri-phased
           case 3:
             connector.phaseAssignmentToGrid = { csPhaseL1: OCPPPhase.L1, csPhaseL2: OCPPPhase.L2, csPhaseL3: OCPPPhase.L3 };
@@ -2256,7 +2256,7 @@ export default class OCPPUtils {
       }
     // Organization setting not enabled or charging station not assigned to a site area
     } else {
-      switch (numberOfPhases) {
+      switch (csNumberOfPhases) {
         // Tri-phased
         case 3:
           connector.phaseAssignmentToGrid = { csPhaseL1: OCPPPhase.L1, csPhaseL2: OCPPPhase.L2, csPhaseL3: OCPPPhase.L3 };

--- a/src/server/rest/v1/service/ChargingStationService.ts
+++ b/src/server/rest/v1/service/ChargingStationService.ts
@@ -249,7 +249,7 @@ export default class ChargingStationService {
       }
       chargingStation.siteAreaID = siteArea.id;
       chargingStation.siteID = siteArea.siteID;
-      // Check number of phases corresponds to the site area one
+      // Check if number of phases corresponds to the site area one
       for (const connector of chargingStation.connectors) {
         const numberOfConnectedPhase = Utils.getNumberOfConnectedPhases(chargingStation, null, connector.connectorId);
         if (numberOfConnectedPhase !== 1 && siteArea?.numberOfPhases === 1) {

--- a/src/server/rest/v1/service/SiteAreaService.ts
+++ b/src/server/rest/v1/service/SiteAreaService.ts
@@ -103,12 +103,13 @@ export default class SiteAreaService {
           const chargePoint = Utils.getChargePointFromID(chargingStation, connector.chargePointID);
           const numberOfConnectedPhase = Utils.getNumberOfConnectedPhases(chargingStation, chargePoint, connector.connectorId);
           if (numberOfConnectedPhase !== 1 && action === ServerAction.ADD_CHARGING_STATIONS_TO_SITE_AREA) {
-            await Logging.logWarning({
-              tenantID: req.user.tenantID,
-              source: chargingStation.id, action: action,
-              user: req.user, module: MODULE_NAME,
-              method: 'handleAssignChargingStationsToSiteArea',
-              message: `Three phased charging station is assigned to single phased site area '${chargingStation.siteArea.name}'`
+            throw new AppError({
+              source: Constants.CENTRAL_SERVER,
+              action: action,
+              errorCode: HTTPError.THREE_PHASE_CHARGER_ON_SINGLE_PHASE_SITE_AREA,
+              message: `Error occurred while assigning charging station: '${chargingStation.id}'. Charging Station is not single phased`,
+              module: MODULE_NAME, method: 'handleAssignChargingStationsToSiteArea',
+              user: req.user
             });
           }
         }

--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -244,7 +244,6 @@ export enum ServerAction {
   WS_REST_CLIENT_CONNECTION_OPENED = 'WSRestClientConnectionOpened',
   WS_REST_CLIENT_CONNECTION_ERROR = 'WSRestClientConnectionError',
 
-
   NOTIFICATION = 'Notification',
   CHARGING_STATION_STATUS_ERROR = 'ChargingStationStatusError',
   CHARGING_STATION_REGISTERED = 'ChargingStationRegistered',

--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -206,6 +206,7 @@ export enum ServerAction {
   SOCKET_IO = 'SocketIO',
 
   // OCPP server commands
+  BOOT_NOTIFICATION = 'BootNotification',
   AUTHORIZE = 'Authorize',
   HEARTBEAT = 'Heartbeat',
   DIAGNOSTICS_STATUS_NOTIFICATION = 'DiagnosticsStatusNotification',
@@ -213,7 +214,7 @@ export enum ServerAction {
   STATUS_NOTIFICATION = 'StatusNotification',
   START_TRANSACTION = 'StartTransaction',
   STOP_TRANSACTION = 'StopTransaction',
-  METERVALUES = 'MeterValues',
+  METER_VALUES = 'MeterValues',
   DATA_TRANSFER = 'DataTransfer',
 
   EXTRA_INACTIVITY = 'ExtraInactivity',
@@ -243,9 +244,6 @@ export enum ServerAction {
   WS_REST_CLIENT_CONNECTION_OPENED = 'WSRestClientConnectionOpened',
   WS_REST_CLIENT_CONNECTION_ERROR = 'WSRestClientConnectionError',
 
-  BOOT_NOTIFICATION = 'BootNotification',
-
-  METER_VALUES = 'MeterValues',
 
   NOTIFICATION = 'Notification',
   CHARGING_STATION_STATUS_ERROR = 'ChargingStationStatusError',

--- a/src/types/ocpi/OCPILocation.ts
+++ b/src/types/ocpi/OCPILocation.ts
@@ -1,4 +1,5 @@
 import { OCPIBusinessDetails } from './OCPIBusinessDetails';
+import { OCPIDisplayText } from './OCPIDisplayText';
 import { OCPIEvse } from './OCPIEvse';
 
 export interface OCPIPeriod {
@@ -25,7 +26,10 @@ export interface OCPILocation {
     longitude: string;
   };
   operator?: OCPIBusinessDetails;
+  suboperator?: OCPIBusinessDetails;
+  owner?: OCPIBusinessDetails;
   evses: OCPIEvse[];
+  directions?: OCPIDisplayText[];
   last_updated: Date;
   // OCPI specify that attribute as optional but Gireve requires it
   opening_times: OCPIOpeningTimes;


### PR DESCRIPTION
Update: 

+ reverted to previous behaviour on the phase assignment. 

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>