### PR TITLE
[1/3] Migration task to add and fill visualID property to tags

### DIFF
--- a/src/migration/MigrationHandler.ts
+++ b/src/migration/MigrationHandler.ts
@@ -16,6 +16,7 @@ import AddSiteIDToChargingStationTask from './tasks/AddSiteIDToChargingStationTa
 import AddTagTypeTask from './tasks/AddTagTypeTask';
 import AddTransactionRefundStatusTask from './tasks/AddTransactionRefundStatusTask';
 import AddUserInTransactionsTask from './tasks/AddUserInTransactionsTask';
+import AddVisualIDPropertyToTagsTask from './tasks/AddVisualIDPropertyToTagsTask';
 import AlignTagsWithUsersIssuerTask from './tasks/AlignTagsWithUsersIssuerTask';
 import ChangeAssetIssuerFieldTask from './tasks/ChangeAssetIssuerFieldTask';
 import ChangeCryptoKeyTask from './tasks/ChangeCryptoKeyTask';
@@ -129,6 +130,7 @@ export default class MigrationHandler {
         currentMigrationTasks.push(new CleanUpLogicallyDeletedUsersTask());
         currentMigrationTasks.push(new CleanUpCarUsersWithDeletedUsersTask());
         currentMigrationTasks.push(new ChangeAssetIssuerFieldTask());
+        currentMigrationTasks.push(new AddVisualIDPropertyToTagsTask());
         // Get the already done migrations from the DB
         const migrationTasksDone = await MigrationStorage.getMigrations();
         // Check

--- a/src/migration/tasks/AddVisualIDPropertyToTagsTask.ts
+++ b/src/migration/tasks/AddVisualIDPropertyToTagsTask.ts
@@ -1,0 +1,57 @@
+import Constants from '../../utils/Constants';
+import Cypher from '../../utils/Cypher';
+import Logging from '../../utils/Logging';
+import MigrationTask from '../MigrationTask';
+import { ServerAction } from '../../types/Server';
+import Tenant from '../../types/Tenant';
+import TenantStorage from '../../storage/mongodb/TenantStorage';
+import Utils from '../../utils/Utils';
+import global from '../../types/GlobalType';
+
+const MODULE_NAME = 'AddVisualIDPropertyToTagsTask';
+
+export default class AddVisualIDPropertyToTagsTask extends MigrationTask {
+  async migrate(): Promise<void> {
+    const tenants = await TenantStorage.getTenants({}, Constants.DB_PARAMS_MAX_LIMIT);
+    for (const tenant of tenants.result) {
+      await this.migrateTenant(tenant);
+    }
+  }
+
+  async migrateTenant(tenant: Tenant): Promise<void> {
+    // Add the visualID property to tags
+    let updated = 0;
+    // Get Tags
+    const tagsMDB = await global.database.getCollection<any>(tenant.id, 'tags')
+      .find({}).toArray();
+    if (!Utils.isEmptyArray(tagsMDB)) {
+      for (const tagMDB of tagsMDB) {
+        await global.database.getCollection<any>(tenant.id, 'tags').findOneAndUpdate(
+          { _id: tagMDB._id },
+          { $set: { visualID: Cypher.hash(tagMDB._id) } });
+        updated++;
+      }
+    }
+    // Log in the default tenant
+    if (updated > 0) {
+      await Logging.logDebug({
+        tenantID: Constants.DEFAULT_TENANT,
+        module: MODULE_NAME, method: 'migrateTenant',
+        action: ServerAction.MIGRATION,
+        message: `${updated} Tag(s) visualID have been updated in Tenant ${Utils.buildTenantName(tenant)}`
+      });
+    }
+  }
+
+  getVersion(): string {
+    return '1.0';
+  }
+
+  getName(): string {
+    return 'AddVisualIDPropertyToTagsTask';
+  }
+
+  isAsynchronous(): boolean {
+    return true;
+  }
+}

--- a/src/types/Tag.ts
+++ b/src/types/Tag.ts
@@ -6,6 +6,7 @@ import User from './User';
 export default interface Tag extends CreatedUpdatedProps {
   id: string;
   description?: string;
+  visualID?: string;
   issuer: boolean;
   active: boolean;
   userID?: string;


### PR DESCRIPTION
Migration task had to run separately before creating the unique index in the DB. 