### PR TITLE
Fix transaction tests

### DIFF
--- a/src/server/rest/v1/service/TransactionService.ts
+++ b/src/server/rest/v1/service/TransactionService.ts
@@ -525,6 +525,7 @@ export default class TransactionService {
       'currentTotalDurationSecs', 'currentTotalInactivitySecs', 'currentInstantWatts', 'currentTotalConsumptionWh', 'currentStateOfCharge', 'currentInactivityStatus',
       'stop.roundedPrice', 'stop.price', 'stop.priceUnit', 'stop.inactivityStatus', 'stop.stateOfCharge', 'stop.timestamp', 'stop.totalConsumptionWh',
       'stop.totalDurationSecs', 'stop.totalInactivitySecs', 'stop.extraInactivitySecs', 'stop.pricingSource',
+      'userID',
     ];
     // Check Cars
     if (Utils.isComponentActiveFromToken(req.user, TenantComponents.CAR)) {


### PR DESCRIPTION
Add `userID` field back into projectFields. It is needed for the check in `Authorizations.canReadTransaction`. 
It is removed later in the code in case the user who made the request does not have the appropriate permissions (READ on USER entity).