### PR TITLE
Bug fix authorization

### DIFF
--- a/src/server/rest/v1/service/AuthorizationService.ts
+++ b/src/server/rest/v1/service/AuthorizationService.ts
@@ -723,7 +723,7 @@ export default class AuthorizationService {
 
   private static async processDynamicFilters(tenant: Tenant, userToken: UserToken, action: Action, entity: Entity,
       authorizationFilters: AuthorizationFilter, authorizationContext: AuthorizationContext, extraFilters?: Record<string, any>): Promise<void> {
-    if (!Utils.isEmptyArray(authorizationContext.filters)) {
+    if (userToken.role !== UserRole.ADMIN && !Utils.isEmptyArray(authorizationContext.filters)) {
       for (const filter of authorizationContext.filters) {
         // Reset to false
         authorizationFilters.authorized = false;

--- a/src/server/rest/v1/service/AuthorizationService.ts
+++ b/src/server/rest/v1/service/AuthorizationService.ts
@@ -723,6 +723,8 @@ export default class AuthorizationService {
 
   private static async processDynamicFilters(tenant: Tenant, userToken: UserToken, action: Action, entity: Entity,
       authorizationFilters: AuthorizationFilter, authorizationContext: AuthorizationContext, extraFilters?: Record<string, any>): Promise<void> {
+    // TODO: find a better way to address filter overlapping in case one user has multiple roles (like admin+siteOwner)
+    // userToken.role !== UserRole.ADMIN check should be removed then
     if (userToken.role !== UserRole.ADMIN && !Utils.isEmptyArray(authorizationContext.filters)) {
       for (const filter of authorizationContext.filters) {
         // Reset to false


### PR DESCRIPTION
Fixes: `admin that are also site admin or owner can't see everything in the organisation tree`

The problem is that extra filters added in case the user is siteOwner or siteAdmin overlap with the fact that an admin can do anything. For now I can add a check that prevents dynamic filters from being applied in case the user is an admin. But the issue will need to be revisited when Serge is back to see what is the elegant way to address it. (I think that after all the entities will be updated to the new auth concept, it won't be an issue anymore, but I need to check with Serge.)