### PR TITLE
Billing - stripe - country code in addresses

### DIFF
--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -555,15 +555,13 @@ export default class StripeBillingIntegration extends BillingIntegration {
       const paymentMethod: Stripe.PaymentMethod = await this.stripe.paymentMethods.attach(paymentMethodId, {
         customer: customerID
       });
-
       // Add billing_details to the payment method
-      // TODO - Stripe expects a Two-letter country code (ISO 3166-1 alpha-2) in the address
-      // await this.stripe.paymentMethods.update(
-      //   paymentMethodId, {
-      //     billing_details: StripeHelpers.buildBillingDetails(user)
-      //   }
-      // );
-
+      // Stripe expects a Two-letter country code (ISO 3166-1 alpha-2) in the address
+      await this.stripe.paymentMethods.update(
+        paymentMethodId, {
+          billing_details: StripeHelpers.buildBillingDetails(user)
+        }
+      );
       await Logging.logInfo({
         tenantID: this.tenantID,
         source: Constants.CENTRAL_SERVER,

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -556,12 +556,14 @@ export default class StripeBillingIntegration extends BillingIntegration {
         customer: customerID
       });
       // Add billing_details to the payment method
-      // Stripe expects a Two-letter country code (ISO 3166-1 alpha-2) in the address
-      await this.stripe.paymentMethods.update(
-        paymentMethodId, {
-          billing_details: StripeHelpers.buildBillingDetails(user)
-        }
-      );
+      const billingDetails: Stripe.PaymentMethodUpdateParams.BillingDetails = StripeHelpers.buildBillingDetails(user);
+      let paymentMethodUpdateParams: Stripe.PaymentMethodUpdateParams;
+      if (billingDetails) {
+        paymentMethodUpdateParams = {
+          billing_details: billingDetails
+        };
+      }
+      await this.stripe.paymentMethods.update(paymentMethodId, paymentMethodUpdateParams);
       await Logging.logInfo({
         tenantID: this.tenantID,
         source: Constants.CENTRAL_SERVER,

--- a/src/integration/billing/stripe/StripeHelpers.ts
+++ b/src/integration/billing/stripe/StripeHelpers.ts
@@ -185,7 +185,7 @@ export default class StripeHelpers {
         countryCode = Countries.getAlpha2Code(countryName, lang); // converts 'Deutschland' to 'DE' when lang is 'de'
       }
       if (!countryCode && locale !== Constants.DEFAULT_LOCALE) {
-        // Fallback - try it again with the 'en' language
+        // Fallback - try it again with the default language
         countryCode = Countries.getAlpha2Code(countryName, Constants.DEFAULT_LANGUAGE); // converts 'Germany' to 'DE' when lang is 'en'
       }
     }

--- a/src/integration/billing/stripe/StripeHelpers.ts
+++ b/src/integration/billing/stripe/StripeHelpers.ts
@@ -143,15 +143,16 @@ export default class StripeHelpers {
   }
 
   public static buildBillingDetails(user: User): Stripe.PaymentMethodUpdateParams.BillingDetails {
-    if (!user.address) {
-      return null;
-    }
-    return {
+    const billingDetails: Stripe.PaymentMethodUpdateParams.BillingDetails = {
       name: Utils.buildUserFullName(user, false, false),
       email: user.email,
       /* phone: user.phone, */
-      address: StripeHelpers.buildStripeAddress(user)
     };
+    const address = StripeHelpers.buildStripeAddress(user);
+    if (address) {
+      billingDetails.address = address;
+    }
+    return billingDetails;
   }
 
   public static buildStripeAddress(user: User): Stripe.Address {


### PR DESCRIPTION
Stripe expects a Two-letter country code (ISO 3166-1 alpha-2)

- The country entered in the address of the customer is converted to the Alpha 2 code when creating/updating the corresponding data on the stripe side.
- Same logic applies when creating a payment method. The billing details information attached to the card information benefit from the same country code conversion logic.

**Known restriction**: The end user must provide the country name using his/her locale. In other words, entering Germany, when  your language is 'de', is not supported. A German end-user has to enter 'Deutschland' instead!
