### PR TITLE
Logging: use lodash clone to avoid circular structure conversion error

### DIFF
--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -5,6 +5,8 @@ export enum ServerAction {
   PING = 'Ping',
   CHECK_CONNECTION = 'CheckConnection',
 
+  OBJECT_CLONE = 'ObjectClone',
+
   CHARGING_STATION_CLIENT_INITIALIZATION = 'ChargingStationClientInitialization',
   CHARGING_STATION_RESET = 'ChargingStationReset',
   CHARGING_STATION_REQUEST_OCPP_PARAMETERS = 'ChargingStationRequestOcppParameters',

--- a/src/utils/Logging.ts
+++ b/src/utils/Logging.ts
@@ -21,7 +21,6 @@ import { ServerAction } from '../types/Server';
 import User from '../types/User';
 import UserToken from '../types/UserToken';
 import Utils from './Utils';
-import _ from 'lodash';
 import chalk from 'chalk';
 import cluster from 'cluster';
 import sizeof from 'object-sizeof';
@@ -804,17 +803,7 @@ export default class Logging {
     if (log.detailedMessages) {
       // Anonymize message
       if (!Utils.isDevelopmentEnv()) {
-        try {
-          log.detailedMessages = _.clone(log.detailedMessages);
-        } catch (error) {
-          await Logging.logError({
-            tenantID: log.tenantID,
-            module: MODULE_NAME,
-            method: '_log',
-            action: ServerAction.LOGGING,
-            message: 'Failed to clone log detailed message attribute'
-          });
-        }
+        log.detailedMessages = Utils.cloneObject(log.detailedMessages);
         log.detailedMessages = await Logging.anonymizeSensitiveData(log.detailedMessages);
       }
       // Array?

--- a/src/utils/Logging.ts
+++ b/src/utils/Logging.ts
@@ -21,6 +21,7 @@ import { ServerAction } from '../types/Server';
 import User from '../types/User';
 import UserToken from '../types/UserToken';
 import Utils from './Utils';
+import _ from 'lodash';
 import chalk from 'chalk';
 import cluster from 'cluster';
 import sizeof from 'object-sizeof';
@@ -803,7 +804,17 @@ export default class Logging {
     if (log.detailedMessages) {
       // Anonymize message
       if (!Utils.isDevelopmentEnv()) {
-        log.detailedMessages = Utils.cloneObject(log.detailedMessages);
+        try {
+          log.detailedMessages = _.clone(log.detailedMessages);
+        } catch (error) {
+          await Logging.logError({
+            tenantID: log.tenantID,
+            module: MODULE_NAME,
+            method: '_log',
+            action: ServerAction.LOGGING,
+            message: 'Failed to clone log detailed message attribute'
+          });
+        }
         log.detailedMessages = await Logging.anonymizeSensitiveData(log.detailedMessages);
       }
       // Array?

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -15,6 +15,7 @@ import ConnectorStats from '../types/ConnectorStats';
 import Constants from './Constants';
 import Cypher from './Cypher';
 import { Decimal } from 'decimal.js';
+import Logging from './Logging';
 import { ObjectID } from 'mongodb';
 import QRCode from 'qrcode';
 import { Request } from 'express';
@@ -38,6 +39,8 @@ import path from 'path';
 import tzlookup from 'tz-lookup';
 import { v4 as uuid } from 'uuid';
 import validator from 'validator';
+
+const MODULE_NAME = 'Utils';
 
 export default class Utils {
   public static getConnectorsFromChargePoint(chargingStation: ChargingStation, chargePoint: ChargePoint): Connector[] {
@@ -1076,7 +1079,20 @@ export default class Utils {
     if (Utils.isNullOrUndefined(object)) {
       return object;
     }
-    return JSON.parse(JSON.stringify(object)) as T;
+    let cloneObject: T;
+    try {
+      cloneObject = _.clone(object);
+    } catch (error) {
+      void Logging.logError({
+        tenantID: Constants.DEFAULT_TENANT,
+        module: MODULE_NAME,
+        method: 'cloneObject',
+        action: ServerAction.LOGGING,
+        message: `Failed to clone object with error: ${error}`,
+        detailedMessages: { error }
+      });
+    }
+    return cloneObject;
   }
 
   public static getConnectorLetterFromConnectorID(connectorID: number): string {


### PR DESCRIPTION
And use try catch construct to avoid crashing the execution if the
cloning fails.

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>