### PR TITLE
Billing stripe country code in address

### DIFF
--- a/src/integration/billing/stripe/StripeHelpers.ts
+++ b/src/integration/billing/stripe/StripeHelpers.ts
@@ -156,7 +156,8 @@ export default class StripeHelpers {
   }
 
   public static buildStripeAddress(user: User): Stripe.Address {
-    if (!user.address) {
+    if (!user.address?.country) {
+      // Stripe does not support addresses where the country is not set!
       return null;
     }
     const { address1: line1, address2: line2, postalCode: postal_code, city, /* department, */ region, country } = user.address;


### PR DESCRIPTION
Billing Details - Make it secure when the country is not set or empty