### PR TITLE
Billing - test data cleanup

### DIFF
--- a/src/storage/mongodb/BillingStorage.ts
+++ b/src/storage/mongodb/BillingStorage.ts
@@ -26,6 +26,12 @@ export default class BillingStorage {
     return invoicesMDB.count === 1 ? invoicesMDB.result[0] : null;
   }
 
+  public static async getInvoicesInTestMode(tenantID: string): Promise<DataResult<BillingInvoice>> {
+    // Returns all invoices that are to be finalized and paid
+    const invoicesMDB = await BillingStorage.getInvoices(tenantID, { liveMode: false }, Constants.DB_PARAMS_MAX_LIMIT);
+    return invoicesMDB;
+  }
+
   public static async getInvoicesToProcess(tenantID: string): Promise<DataResult<BillingInvoice>> {
     // Returns all invoices that are to be finalized and paid
     const invoicesMDB = await BillingStorage.getInvoices(tenantID, {
@@ -45,7 +51,7 @@ export default class BillingStorage {
   public static async getInvoices(tenantID: string,
       params: {
         invoiceIDs?: string[]; billingInvoiceID?: string; search?: string; userIDs?: string[]; invoiceStatus?: BillingInvoiceStatus[];
-        startDateTime?: Date; endDateTime?: Date;
+        startDateTime?: Date; endDateTime?: Date; liveMode?: boolean
       } = {},
       dbParams: DbParams, projectFields?: string[]): Promise<DataResult<BillingInvoice>> {
     // Debug
@@ -81,6 +87,10 @@ export default class BillingStorage {
     }
     if (params.billingInvoiceID) {
       filters.invoiceID = { $eq: params.billingInvoiceID };
+    }
+    // liveMode (to clear test data)
+    if (params.liveMode) {
+      filters.liveMode = { $eq: params.liveMode };
     }
     // Status
     if (!Utils.isEmptyArray(params.invoiceStatus)) {

--- a/src/storage/mongodb/UserStorage.ts
+++ b/src/storage/mongodb/UserStorage.ts
@@ -485,20 +485,26 @@ export default class UserStorage {
     const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'saveUserBillingData');
     // Check Tenant
     await DatabaseUtils.checkTenant(tenantID);
+    if (billingData) {
     // Set data
-    const updatedUserMDB: any = {
-      billingData: {
-        customerID: billingData.customerID,
-        liveMode: Utils.convertToBoolean(billingData.liveMode),
-        hasSynchroError: billingData.hasSynchroError,
-        invoicesLastSynchronizedOn: Utils.convertToDate(billingData.invoicesLastSynchronizedOn),
-        lastChangedOn: Utils.convertToDate(billingData.lastChangedOn),
-      }
-    };
-    // Modify and return the modified document
-    await global.database.getCollection(tenantID, 'users').findOneAndUpdate(
-      { '_id': Utils.convertToObjectID(userID) },
-      { $set: updatedUserMDB });
+      const updatedUserMDB: any = {
+        billingData: {
+          customerID: billingData.customerID,
+          liveMode: Utils.convertToBoolean(billingData.liveMode),
+          hasSynchroError: billingData.hasSynchroError,
+          invoicesLastSynchronizedOn: Utils.convertToDate(billingData.invoicesLastSynchronizedOn),
+          lastChangedOn: Utils.convertToDate(billingData.lastChangedOn),
+        }
+      };
+      // Modify and return the modified document
+      await global.database.getCollection(tenantID, 'users').findOneAndUpdate(
+        { '_id': Utils.convertToObjectID(userID) },
+        { $set: updatedUserMDB });
+    } else {
+      await global.database.getCollection(tenantID, 'users').findOneAndUpdate(
+        { '_id': Utils.convertToObjectID(userID) },
+        { $unset: { billingData: '' } }); // This removes the field from the document
+    }
     // Debug
     await Logging.traceEnd(tenantID, MODULE_NAME, 'saveUserBillingData', uniqueTimerID, billingData);
   }
@@ -532,7 +538,8 @@ export default class UserStorage {
         notificationsActive?: boolean; siteIDs?: string[]; excludeSiteID?: string; search?: string;
         includeCarUserIDs?: string[]; excludeUserIDs?: string[]; notAssignedToCarID?: string;
         userIDs?: string[]; email?: string; issuer?: boolean; passwordResetHash?: string; roles?: string[];
-        statuses?: string[]; withImage?: boolean; billingUserID?: string; notSynchronizedBillingData?: boolean;
+        statuses?: string[]; withImage?: boolean; billingUserID?: string;
+        notSynchronizedBillingData?: boolean; withTestBillingData?: boolean;
         notifications?: any; noLoginSince?: Date; tagIDs?: string[];
       },
       dbParams: DbParams, projectFields?: string[]): Promise<DataResult<User>> {
@@ -611,6 +618,14 @@ export default class UserStorage {
         { 'billingData.lastChangedOn': { '$exists': false } },
         { 'billingData.lastChangedOn': null },
         { $expr: { $gt: ['$lastChangedOn', '$billingData.lastChangedOn'] } }
+      ];
+    }
+    // Select users with test billing data
+    if (params.withTestBillingData) {
+      const expectedLiveMode = !params.withTestBillingData;
+      filters.$and = [
+        { 'billingData': { '$exists': true } },
+        { 'billingData.liveMode': { $eq: expectedLiveMode } }
       ];
     }
     // Add filters

--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -426,6 +426,7 @@ export enum ServerAction {
   BILLING_DELETE_PAYMENT_METHOD = 'BillingDeletePaymentMethod',
   BILLING_CHARGE_INVOICE = 'BillingChargeInvoice',
   BILLING_WEB_HOOK = 'BillingWebHook',
+  BILLING_TEST_DATA_CLEANUP = 'BillingTestDataCleanup',
 
   MONGO_DB = 'MongoDB',
 

--- a/test/api/BillingStripeTestData.ts
+++ b/test/api/BillingStripeTestData.ts
@@ -289,6 +289,13 @@ export default class StripeIntegrationTestData {
     return customerID;
   }
 
+  public async checkNoInvoices() : Promise<void> {
+    const paging = TestConstants.DEFAULT_PAGING;
+    const ordering = [{ field: '-createdOn' }];
+    const response = await this.adminUserService.billingApi.readInvoices({}, paging, ordering);
+    assert(response?.data?.result.length === 0, 'There should be no invoices anymore');
+  }
+
   public async checkForDraftInvoices(userId: string, expectedValue: number): Promise<number> {
     const result = await this.getInvoicesByState(userId, BillingInvoiceStatus.DRAFT);
     assert(result?.length === expectedValue, 'The number of invoice is not the expected one');
@@ -342,5 +349,10 @@ export default class StripeIntegrationTestData {
     // Let's now try to repair the user data.
     const billingUser: BillingUser = await this.billingImpl.forceSynchronizeUser(user);
     expect(corruptedBillingData.customerID).to.not.be.eq(billingUser.billingData.customerID);
+  }
+
+  public async checkTestDataCleanup(): Promise<void> {
+    await this.billingImpl.clearTestData();
+    await this.checkNoInvoices();
   }
 }

--- a/test/api/BillingStripeTestData.ts
+++ b/test/api/BillingStripeTestData.ts
@@ -290,10 +290,20 @@ export default class StripeIntegrationTestData {
   }
 
   public async checkNoInvoices() : Promise<void> {
-    const paging = TestConstants.DEFAULT_PAGING;
-    const ordering = [{ field: '-createdOn' }];
-    const response = await this.adminUserService.billingApi.readInvoices({}, paging, ordering);
-    assert(response?.data?.result.length === 0, 'There should be no invoices anymore');
+    const response = await this.adminUserService.billingApi.readInvoices({}, { limit: 1, skip: 0 });
+    assert(response?.data?.result.length === 0, 'There should be no invoices with test billing data anymore');
+  }
+
+  public async checkNoUsersWithTestData() : Promise<void> {
+    // const response = await this.adminUserService.userApi.readAll({ withTestBillingData: true }, { limit: 1, skip: 0 });
+    // assert(response?.data?.result.length === 0, 'There should be no users with test billing data anymore');
+    const response = await UserStorage.getUsers(this.getTenantID(), {
+      withTestBillingData: true
+    }, {
+      limit: 1,
+      skip: 0
+    }, ['id']);
+    assert(response?.result.length === 0, 'There should be no invoices with test billing data anymore');
   }
 
   public async checkForDraftInvoices(userId: string, expectedValue: number): Promise<number> {
@@ -354,5 +364,6 @@ export default class StripeIntegrationTestData {
   public async checkTestDataCleanup(): Promise<void> {
     await this.billingImpl.clearTestData();
     await this.checkNoInvoices();
+    await this.checkNoUsersWithTestData();
   }
 }

--- a/test/api/BillingTestDataCleanupTest.ts
+++ b/test/api/BillingTestDataCleanupTest.ts
@@ -1,0 +1,37 @@
+import MongoDBStorage from '../../src/storage/mongodb/MongoDBStorage';
+import StripeIntegrationTestData from './BillingStripeTestData';
+import chai from 'chai';
+import chaiSubset from 'chai-subset';
+import config from '../config';
+import global from '../../src/types/GlobalType';
+import responseHelper from '../helpers/responseHelper';
+
+chai.use(chaiSubset);
+chai.use(responseHelper);
+
+const testData: StripeIntegrationTestData = new StripeIntegrationTestData();
+
+describe('Billing Test Data Cleanup', function() {
+  // Do not run the tests when the settings are not properly set
+  this.pending = !testData.isBillingProperlyConfigured();
+  this.timeout(1000000);
+
+  describe('With component Billing (tenant utbilling)', () => {
+    before(async () => {
+      global.database = new MongoDBStorage(config.get('storage'));
+      await global.database.start();
+      await testData.initialize();
+      await testData.forceBillingSettings(true);
+    });
+
+    after(async () => {
+      // Cleanup of the utbilling tenant is useless
+      // Anyway, there is no way to cleanup the utbilling stripe account!
+    });
+
+    it('should cleanup all billing test data', async () => {
+      await testData.checkTestDataCleanup();
+    });
+  });
+
+});


### PR DESCRIPTION
The purpose of these changes is to make it possible for the customer to experiment the stripe integration with a stripe test account.
As a consequence, we need to be able to clear all test data once the customer goes live.

new methods have been added to:
-  delete all invoices with **liveMode** set to false and clear the corresponding billingData aattched to the corresponding transactions.
- clear all users having a billingData with liveMode set to false. The purpose here is to get rid of all STRIPE customer references.

So far, no endpoints are using the new methods.
However, utBilling tests can be used to check the behavior!
