### PR TITLE
Billing - lazy synch user

### DIFF
--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -475,7 +475,13 @@ export default class StripeBillingIntegration extends BillingIntegration {
     // Check Stripe
     await this.checkConnection();
     // Check billing data consistency
-    const customerID = user?.billingData?.customerID;
+    let customerID = user?.billingData?.customerID;
+    if (!customerID) {
+      // User Sync is now made implicitly - LAZY mode
+      const billingUser = await this.synchronizeUser(user);
+      customerID = billingUser?.billingData?.customerID;
+    }
+    // User should now exist
     if (!customerID) {
       throw new BackendError({
         message: `User is not known in Stripe: '${user.id}' - (${user.email})`,

--- a/src/storage/mongodb/UserStorage.ts
+++ b/src/storage/mongodb/UserStorage.ts
@@ -1,3 +1,4 @@
+import FeatureToggles, { Feature } from '../../utils/FeatureToggles';
 import Site, { SiteUser } from '../../types/Site';
 import User, { ImportedUser, UserRole, UserStatus } from '../../types/User';
 import { UserInError, UserInErrorType } from '../../types/InError';
@@ -875,6 +876,10 @@ export default class UserStorage {
     for (const type of params.errorTypes) {
       if ((type === UserInErrorType.NOT_ASSIGNED && !Utils.isTenantComponentActive(tenant, TenantComponents.ORGANIZATION)) ||
         ((type === UserInErrorType.NO_BILLING_DATA || type === UserInErrorType.FAILED_BILLING_SYNCHRO) && !Utils.isTenantComponentActive(tenant, TenantComponents.BILLING))) {
+        continue;
+      }
+      if (type === UserInErrorType.NO_BILLING_DATA && !FeatureToggles.isFeatureActive(Feature.BILLING_SYNC_USERS)) {
+        // LAZY User Synchronization - no BillingData is not an Error anymore
         continue;
       }
       array.push(`$${type}`);

--- a/src/utils/FeatureToggles.ts
+++ b/src/utils/FeatureToggles.ts
@@ -16,7 +16,7 @@ export enum Feature {
 export default class FeatureToggles {
   // Comment out the features that you want to switch OFF
   static activeFeatures: Feature[] = [
-    Feature.BILLING_SYNC_USERS,
+    // Feature.BILLING_SYNC_USERS, - When switched OFF the sync of the user should be implicit (LAZY mode)
     Feature.BILLING_SYNC_USER,
     Feature.BILLING_CHECK_USER_BILLING_DATA,
     Feature.BILLING_CHECK_CUSTOMER_ID,

--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -775,7 +775,12 @@ describe('Billing Service', function() {
             break;
           }
         }
-        assert(userFound, 'User with no billing data not found in Users In Error');
+        if (FeatureToggles.isFeatureActive(Feature.BILLING_SYNC_USERS)) {
+          assert(userFound, 'User with no billing data should be listed as a User In Error');
+        } else {
+          // LAZY User Sync - The billing data will be created on demand (i.e.: when entering a payment method)
+          assert(!userFound, 'User with no billing data should not be listed as a User In Error');
+        }
       });
 
     });


### PR DESCRIPTION
**Lazy Synch Users**
- a LAZY synchronize user mode as been introduced to AVOID the need to create all customers (on the STRIPE).
- The user synchronization is now postponed and done only when the end-user creates its first payment method.

The advantage of this approach is that the billing setup (and the activation of the billing of the transaction) does not require to wait for a complete synchronization.

The "User in Errors" tab has been adapted as well. Users with no Billing Data are not shown as "**Users in Error**" anymore
