### PR TITLE
billing - do not bill internal users on SLF

### DIFF
--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -716,6 +716,18 @@ export default class StripeBillingIntegration extends BillingIntegration {
     }
   }
 
+  private isTransactionUserInternal(transaction: Transaction): boolean {
+    // slf
+    if (this.tenantID === '5be7fb271014d90008992f06') {
+      if (transaction?.user?.email?.toLocaleLowerCase()?.endsWith('@sap.com')) {
+        // Internal user
+        return true;
+      }
+    }
+    // This is an external user
+    return false;
+  }
+
   public async startTransaction(transaction: Transaction): Promise<BillingDataTransactionStart> {
 
     if (!this.settings.billing.isTransactionBillingActivated) {
@@ -724,7 +736,13 @@ export default class StripeBillingIntegration extends BillingIntegration {
         withBillingActive: false
       };
     }
-
+    // Temporary solution - Check for internal users
+    if (this.isTransactionUserInternal(transaction)) {
+      return {
+        // Do not bill internal users
+        withBillingActive: false
+      };
+    }
     // Check Stripe
     await this.checkConnection();
     // Check Transaction


### PR DESCRIPTION
This is a proposal for a temporary solution to allow activating the billing on SLF while enabling it only for external users.

The temporary solution simply checks for the id of the SLF tenant and considers the user to be internal when his/her email ends with '@sap.com' 