### PR TITLE
Billing - invoice statuses

### DIFF
--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -247,7 +247,7 @@ export default abstract class BillingIntegration {
           evseDashboardURL: Utils.buildEvseURL(tenant.subdomain),
           invoiceDownloadUrl: Utils.buildEvseBillingDownloadInvoicesURL(tenant.subdomain, billingInvoice.id),
           // Empty url allows to decide wether to display "pay" button in the email
-          payInvoiceUrl: billingInvoice.status === 'open' ? billingInvoice.payInvoiceUrl : '',
+          payInvoiceUrl: billingInvoice.status === BillingInvoiceStatus.OPEN ? billingInvoice.payInvoiceUrl : '',
           // Stripe saves amount in cents
           invoiceAmount: Utils.createDecimal(billingInvoice.amount).div(100),
           invoiceNumber: billingInvoice.number,

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -447,13 +447,14 @@ export default class StripeBillingIntegration extends BillingIntegration {
       // Fetch the invoice from stripe (do NOT TRUST the local copy)
       let stripeInvoice: Stripe.Invoice = await this.stripe.invoices.retrieve(invoiceID);
       // Check the current invoice status
-      if (stripeInvoice.status !== 'paid') {
+      if (stripeInvoice.status !== BillingInvoiceStatus.PAID) {
         // Finalize the invoice (if necessary)
-        if (stripeInvoice.status === 'draft') {
+        if (stripeInvoice.status === BillingInvoiceStatus.DRAFT) {
           stripeInvoice = await this.stripe.invoices.finalizeInvoice(invoiceID);
         }
         // Once finalized, the invoice is in the "open" state!
-        if (stripeInvoice.status === 'open') {
+        if (stripeInvoice.status === BillingInvoiceStatus.OPEN
+          || stripeInvoice.status === BillingInvoiceStatus.UNCOLLECTIBLE) {
           // Set the payment options
           const paymentOptions: Stripe.InvoicePayParams = {};
           stripeInvoice = await this.stripe.invoices.pay(invoiceID, paymentOptions);

--- a/src/types/Billing.ts
+++ b/src/types/Billing.ts
@@ -113,6 +113,9 @@ export enum BillingInvoiceStatus {
   PAID = 'paid',
   OPEN = 'open',
   DRAFT = 'draft',
+  VOID = 'void',
+  UNCOLLECTIBLE = 'uncollectible',
+  DELETED = 'deleted',
 }
 
 export interface BillingOperationResult {


### PR DESCRIPTION
Invoice status from STRIPE includes stuff like VOID, UNCOLLECTIBLE and DELETED.

- The code has been changed to make sure these additional states do not have any side-effect when transitioning the invoices from one state to the other.

Note:
- Both the web app and mobile apps need to be changed to properly display these additional invoice statuses. This will be done separately (the corresponding issue has been created already).
