### PR TITLE
Add owner filter in assets

### DIFF
--- a/src/authorization/AuthorizationsDefinition.ts
+++ b/src/authorization/AuthorizationsDefinition.ts
@@ -158,7 +158,7 @@ const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
         resource: Entity.ASSETS, action: [Action.LIST, Action.IN_ERROR],
         attributes: [
           'id', 'name', 'siteAreaID', 'siteArea.id', 'siteArea.name', 'siteArea.siteID', 'siteID', 'assetType', 'coordinates',
-          'dynamicAsset', 'connectionID', 'meterID', 'currentInstantWatts', 'currentStateOfCharge'
+          'dynamicAsset', 'connectionID', 'meterID', 'currentInstantWatts', 'currentStateOfCharge', 'issuer'
         ]
       },
       { resource: Entity.SETTINGS, action: Action.LIST, attributes: ['*'] },

--- a/src/server/rest/v1/service/AssetService.ts
+++ b/src/server/rest/v1/service/AssetService.ts
@@ -230,6 +230,7 @@ export default class AssetService {
     // Get the assets
     const assets = await AssetStorage.getAssetsInError(req.user.tenantID,
       {
+        issuer: filteredRequest.Issuer,
         search: filteredRequest.Search,
         siteAreaIDs: (filteredRequest.SiteAreaID ? filteredRequest.SiteAreaID.split('|') : null),
         siteIDs: (filteredRequest.SiteID ? filteredRequest.SiteID.split('|') : null),
@@ -373,6 +374,7 @@ export default class AssetService {
     const assets = await AssetStorage.getAssets(req.user.tenantID,
       {
         search: filteredRequest.Search,
+        issuer: filteredRequest.Issuer,
         siteAreaIDs: (filteredRequest.SiteAreaID ? filteredRequest.SiteAreaID.split('|') : null),
         siteIDs: (filteredRequest.SiteID ? filteredRequest.SiteID.split('|') : null),
         withSiteArea: filteredRequest.WithSiteArea,

--- a/src/server/rest/v1/service/security/AssetSecurity.ts
+++ b/src/server/rest/v1/service/security/AssetSecurity.ts
@@ -35,6 +35,9 @@ export default class AssetSecurity {
       DynamicOnly: UtilsSecurity.filterBoolean(request.DynamicOnly),
       ErrorType: sanitize(request.ErrorType)
     } as HttpAssetsRequest;
+    if (Utils.objectHasProperty(request, 'Issuer')) {
+      filteredRequest.Issuer = UtilsSecurity.filterBoolean(request.Issuer);
+    }
     UtilsSecurity.filterSkipAndLimit(request, filteredRequest);
     UtilsSecurity.filterSort(request, filteredRequest);
     return filteredRequest;

--- a/src/storage/mongodb/AssetStorage.ts
+++ b/src/storage/mongodb/AssetStorage.ts
@@ -206,6 +206,8 @@ export default class AssetStorage {
     // Project
     DatabaseUtils.projectFields(aggregation, projectFields);
     // Read DB
+    console.log("Testing aggregation");
+    console.log(aggregation);
     const assetsMDB = await global.database.getCollection<any>(tenantID, 'assets')
       .aggregate(aggregation, {
         allowDiskUse: true
@@ -221,7 +223,7 @@ export default class AssetStorage {
   }
 
   public static async getAssetsInError(tenantID: string,
-      params: { search?: string; siteAreaIDs?: string[]; siteIDs?: string[]; errorType?: string[] } = {},
+      params: { search?: string; siteAreaIDs?: string[]; siteIDs?: string[]; errorType?: string[]; issuer?: boolean  } = {},
       dbParams?: DbParams, projectFields?: string[]): Promise<DataResult<Asset>> {
     // Debug
     const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'getAssetsInError');
@@ -245,6 +247,9 @@ export default class AssetStorage {
     }
     if (!Utils.isEmptyArray(params.siteIDs)) {
       filters.siteID = { $in: params.siteIDs.map((id) => Utils.convertToObjectID(id)) };
+    }
+    if (Utils.objectHasProperty(params, 'issuer') && Utils.isBoolean(params.issuer)) {
+      filters.issuer = params.issuer;
     }
     // Create Aggregation
     const aggregation = [];

--- a/src/storage/mongodb/AssetStorage.ts
+++ b/src/storage/mongodb/AssetStorage.ts
@@ -206,8 +206,6 @@ export default class AssetStorage {
     // Project
     DatabaseUtils.projectFields(aggregation, projectFields);
     // Read DB
-    console.log("Testing aggregation");
-    console.log(aggregation);
     const assetsMDB = await global.database.getCollection<any>(tenantID, 'assets')
       .aggregate(aggregation, {
         allowDiskUse: true

--- a/src/types/requests/HttpAssetRequest.ts
+++ b/src/types/requests/HttpAssetRequest.ts
@@ -6,6 +6,7 @@ export interface HttpAssetRequest extends HttpByIDRequest {
 }
 
 export interface HttpAssetsRequest extends HttpDatabaseRequest {
+  Issuer?: boolean;
   Search?: string;
   SiteAreaID?: string;
   SiteID?: string;


### PR DESCRIPTION
Adding owner filter in Assets and Asset in Error page. This requires the issuer property to be passed to the request allowing for differentiation between "Current Organization" assets and "External Organization" assets. Also, the same issuer field must also be passed back to each Asset entry allowing for an asset to be modifiable or not. 