### PR TITLE
Change Tenant Id to Object Connection Storage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,19 +6,20 @@
   },
   "plugins": [
     "eslint-plugin-import",
-    "eslint-plugin-jsdoc",
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "eslint-plugin-jsdoc"
   ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "plugin:jsdoc/recommended",
     "plugin:import/errors",
+    "plugin:jsdoc/recommended",
     "plugin:import/warnings",
     "plugin:import/typescript"
   ],
   "rules": {
+    "jsdoc/require-jsdoc": "off",
     "indent": "off",
     "@typescript-eslint/indent": [
       "error",

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -95,8 +95,8 @@ jobs:
         if [ ! -d test/config ]; then mkdir -p test/config; fi
         cp src/assets/configs-ci/local.json test/config
         npm run mochatest:createContext
-    - name: npm run mochatest:nyc:parallel
-      run: npm run mochatest:nyc:parallel
+    - name: npm run mochatest:nyc
+      run: npm run mochatest:nyc
     - name: npm run coverage
       run: npm run coverage
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
     "TS_NODE_FILES": "true"
   },
   "mochaExplorer.files": "test/**/*Test.ts",
+  "mochaExplorer.parallel": false,
   "mochaExplorer.exit": true,
   "mochaExplorer.debuggerConfig": "Debug Mocha Tests",
   "search.usePCRE2": true

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -142,11 +142,11 @@
     },
     "billingNewInvoicePaid": {
       "title": "Neue beglichene Rechnung",
-      "body": "Ihre Rechnung ({{invoiceNumber}}) in Höhe von {{amount}}€ wurde beglichen und ist nun verfügbar"
+      "body": "Ihre Rechnung ({{invoiceNumber}}) in Höhe von {{amount}} wurde beglichen und ist nun verfügbar"
     },
     "billingNewInvoiceOpen": {
       "title": "Neue offene Rechnung",
-      "body": "Eine neue Rechnung ({{invoiceNumber}}) in Höhe von {{amount}}€ ist jetzt verfügbar. Bitte prüfen Sie die E-Mail, um die Zahlung abzuschließen"
+      "body": "Eine neue Rechnung ({{invoiceNumber}}) in Höhe von {{amount}} ist jetzt verfügbar. Bitte prüfen Sie die E-Mail, um die Zahlung abzuschließen"
     },
     "endUserErrorNotification": {
       "title": "Ein Nutzer hat einen Fehler gemeldet",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -142,11 +142,11 @@
     },
     "billingNewInvoicePaid": {
       "title": "New invoice paid",
-      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}}€ has been paid and is now available"
+      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}} has been paid and is now available"
     },
     "billingNewInvoiceOpen": {
       "title": "New invoice to pay",
-      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}}€ is now available. Please check your email to finalize the payment"
+      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}} is now available. Please check your email to finalize the payment"
     },
     "endUserErrorNotification": {
       "title": "A User Reported an Error",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -142,11 +142,11 @@
     },
     "billingNewInvoicePaid": {
       "title": "New invoice paid",
-      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}}€ has been paid and is now available"
+      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}} has been paid and is now available"
     },
     "billingNewInvoiceOpen": {
       "title": "New invoice to pay",
-      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}}€ is now available. Please check your email to finalize the payment"
+      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}} is now available. Please check your email to finalize the payment"
     },
     "endUserErrorNotification": {
       "title": "Un usuario ha reportado un error",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -142,11 +142,11 @@
     },
     "billingNewInvoicePaid": {
       "title": "Nouvelle facture payée",
-      "body": "Une nouvelle facture ({{invoiceNumber}}) d'un montant de {{amount}}€ a été payée et est maintenant disponible"
+      "body": "Une nouvelle facture ({{invoiceNumber}}) d'un montant de {{amount}} a été payée et est maintenant disponible"
     },
     "billingNewInvoiceOpen": {
       "title": "Nouvelle facture a payer",
-      "body": "Une nouvelle facture ({{invoiceNumber}}) d'un montant de {{amount}}€ est disponible, vérifiez vos emails pour finaliser le paiement"
+      "body": "Une nouvelle facture ({{invoiceNumber}}) d'un montant de {{amount}} est disponible, vérifiez vos emails pour finaliser le paiement"
     },
     "endUserErrorNotification": {
       "title": "Un utitilisateur a reporté une erreur",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -142,11 +142,11 @@
     },
     "billingNewInvoicePaid": {
       "title": "New invoice paid",
-      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}}€ has been paid and is now available"
+      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}} has been paid and is now available"
     },
     "billingNewInvoiceOpen": {
       "title": "New invoice to pay",
-      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}}€ is now available. Please check your email to finalize the payment"
+      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}} is now available. Please check your email to finalize the payment"
     },
     "endUserErrorNotification": {
       "title": "Un utente ha riportato un errore",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -142,11 +142,11 @@
     },
     "billingNewInvoicePaid": {
       "title": "New invoice paid",
-      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}}€ has been paid and is now available"
+      "body": "Your invoice ({{invoiceNumber}}) amounting {{amount}} has been paid and is now available"
     },
     "billingNewInvoiceOpen": {
       "title": "New invoice to pay",
-      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}}€ is now available. Please check your email to finalize the payment"
+      "body": "A new invoice ({{invoiceNumber}}) amounting {{amount}} is now available. Please check your email to finalize the payment"
     },
     "endUserErrorNotification": {
       "title": "Um utilizador reportou um erro",

--- a/src/assets/server/notification/email/de_DE/billing-new-invoice.json
+++ b/src/assets/server/notification/email/de_DE/billing-new-invoice.json
@@ -22,7 +22,7 @@
       "<% if(invoiceStatus === 'paid'){ %> Ihre Rechnung <%- invoiceNumber %> wurde bezahlt und ist jetzt verfügbar. <% } else { %> Eine neue Rechnung ist verfügbar : <%- invoiceNumber %>. <br/><br/> Bitte folgen Sie dem unten stehenden Link, um die Zahlung abzuschließen <% } %>"
     ],
     "stats": [
-      { "label": "Kosten", "value": "<%- invoiceAmount %>€" }
+      { "label": "<% if(invoiceStatus === 'paid'){ %> Amount paid <% } else { %> Amount due <% } %>", "value": "<%- invoiceAmount %>" }
     ],
     "actions": [{
         "title": "Rechnungen ansehen",

--- a/src/assets/server/notification/email/en_US/billing-new-invoice.json
+++ b/src/assets/server/notification/email/en_US/billing-new-invoice.json
@@ -22,10 +22,10 @@
       "<% if(invoiceStatus === 'paid'){ %> Your invoice <%- invoiceNumber %> has been paid and is now available. <% } else { %> A new invoice is available : <%- invoiceNumber %>. <br/><br/> Please follow the link below to finalize the payment <% } %>"
     ],
     "stats": [
-      { "label": "Cost", "value": "<%- invoiceAmount %>€" }
+      { "label": "<% if(invoiceStatus === 'paid'){ %> Amount paid <% } else { %> Amount due <% } %>", "value": "<%- invoiceAmount %>" }
     ],
     "actions": [{
-        "title": "Consult invoices list",
+        "title": "Consult invoices",
         "url": "<%- evseDashboardInvoiceURL %>"
       }, {
         "title": "Download invoice",

--- a/src/assets/server/notification/email/es_MX/billing-new-invoice.json
+++ b/src/assets/server/notification/email/es_MX/billing-new-invoice.json
@@ -22,10 +22,10 @@
       "<% if(invoiceStatus === 'paid'){ %> Your invoice <%- invoiceNumber %> has been paid and is now available. <% } else { %> A new invoice is available : <%- invoiceNumber %>. <br/><br/> Please follow the link below to finalize the payment <% } %>"
     ],
     "stats": [
-      { "label": "Cost", "value": "<%- invoiceAmount %>€" }
+      { "label": "<% if(invoiceStatus === 'paid'){ %> Amount paid <% } else { %> Amount due <% } %>", "value": "<%- invoiceAmount %>" }
     ],
     "actions": [{
-        "title": "Consult invoices list",
+        "title": "Consult invoices",
         "url": "<%- evseDashboardInvoiceURL %>"
       }, {
         "title": "Download invoice",

--- a/src/assets/server/notification/email/fr_FR/billing-new-invoice.json
+++ b/src/assets/server/notification/email/fr_FR/billing-new-invoice.json
@@ -22,7 +22,7 @@
       "<% if(invoiceStatus === 'paid'){ %> Votre facture <%- invoiceNumber %> a été payée et est maintenant disponible. <% } else { %> Une nouvelle facture est disponible : <%- invoiceNumber %>. <br/><br/> Cliquez sur le lien ci-dessous pour finaliser le paiement. <% } %>"
     ],
     "stats": [
-      { "label": "Coût", "value": "<%- invoiceAmount %>€" }
+      { "label": "<% if(invoiceStatus === 'paid'){ %> Montant payé <% } else { %> Montant dû <% } %>", "value": "<%- invoiceAmount %>" }
     ],
     "actions": [{
       "title": "Consulter",

--- a/src/assets/server/notification/email/it_IT/billing-new-invoice.json
+++ b/src/assets/server/notification/email/it_IT/billing-new-invoice.json
@@ -22,10 +22,10 @@
       "<% if(invoiceStatus === 'paid'){ %> Your invoice <%- invoiceNumber %> has been paid and is now available. <% } else { %> A new invoice is available : <%- invoiceNumber %>. <br/><br/> Please follow the link below to finalize the payment <% } %>"
     ],
     "stats": [
-      { "label": "Cost", "value": "<%- invoiceAmount %>€" }
+      { "label": "<% if(invoiceStatus === 'paid'){ %> Amount paid <% } else { %> Amount due <% } %>", "value": "<%- invoiceAmount %>" }
     ],
     "actions": [{
-        "title": "Consult invoices list",
+        "title": "Consult invoices",
         "url": "<%- evseDashboardInvoiceURL %>"
       }, {
         "title": "Download invoice",

--- a/src/assets/server/notification/email/pt_PT/billing-new-invoice.json
+++ b/src/assets/server/notification/email/pt_PT/billing-new-invoice.json
@@ -22,10 +22,10 @@
       "<% if(invoiceStatus === 'paid'){ %> Your invoice <%- invoiceNumber %> has been paid and is now available. <% } else { %> A new invoice is available : <%- invoiceNumber %>. <br/><br/> Please follow the link below to finalize the payment <% } %>"
     ],
     "stats": [
-      { "label": "Cost", "value": "<%- invoiceAmount %>€" }
+      { "label": "<% if(invoiceStatus === 'paid'){ %> Amount paid <% } else { %> Amount due <% } %>", "value": "<%- invoiceAmount %>" }
     ],
     "actions": [{
-        "title": "Consult invoices list",
+        "title": "Consult invoices",
         "url": "<%- evseDashboardInvoiceURL %>"
       }, {
         "title": "Download invoice",

--- a/src/assets/server/rest/v1/docs/e-mobility-oas.json
+++ b/src/assets/server/rest/v1/docs/e-mobility-oas.json
@@ -4289,6 +4289,171 @@
             "$ref": "#/components/responses/ResourceDoesNotExists"
           }
         }
+      },
+      "put": {
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "description": "Unassign sites to a user",
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "siteIDs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User successfully unassigned to sites",
+            "content": {
+              "application/json": {
+                "example": {
+                  "status": "Success"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/BackendError"
+          },
+          "550": {
+            "$ref": "#/components/responses/ResourceDoesNotExists"
+          }
+        }
+      }
+    },
+    "/api/users/{id}/mobile-token": {
+      "put": {
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "description": "Update user's mobile tokens",
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "mobileToken"
+                ],
+                "properties": {
+                  "mobileToken": {
+                    "type": "string"
+                  },
+                  "mobileOS": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Mobile token successfully updated",
+            "content": {
+              "application/json": {
+                "example": {
+                  "status": "Success"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/BackendError"
+          },
+          "550": {
+            "$ref": "#/components/responses/ResourceDoesNotExists"
+          }
+        }
+      }
+    },
+    "/api/users/{id}/image": {
+      "get": {
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "description": "Get user's image",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/userID"
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved user image",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "User ID"
+                    },
+                    "image": {
+                      "type": "string",
+                      "description": "Base 64 encoded image"
+                    }
+                  }
+                },
+                "example": {
+                  "id": "###",
+                  "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAC..."
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/BackendError"
+          },
+          "550": {
+            "$ref": "#/components/responses/ResourceDoesNotExists"
+          }
+        }
       }
     },
     "/api/tags": {

--- a/src/authorization/Authorizations.ts
+++ b/src/authorization/Authorizations.ts
@@ -693,6 +693,10 @@ export default class Authorizations {
     return Authorizations.canPerformAction(loggedUser, Entity.PRICING, Action.UPDATE);
   }
 
+  public static async canClearBillingTestData(loggedUser: UserToken): Promise<boolean> {
+    return Authorizations.canPerformAction(loggedUser, Entity.BILLING, Action.CLEAR_BILLING_TEST_DATA);
+  }
+
   public static async canCheckBillingConnection(loggedUser: UserToken): Promise<boolean> {
     return Authorizations.canPerformAction(loggedUser, Entity.BILLING, Action.CHECK_CONNECTION);
   }

--- a/src/authorization/AuthorizationsDefinition.ts
+++ b/src/authorization/AuthorizationsDefinition.ts
@@ -158,7 +158,7 @@ const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
       { resource: Entity.LOGGINGS, action: Action.LIST, attributes: ['*'] },
       { resource: Entity.LOGGING, action: Action.READ, attributes: ['*'] },
       { resource: Entity.PRICING, action: [Action.READ, Action.UPDATE], attributes: ['*'] },
-      { resource: Entity.BILLING, action: [Action.CHECK_CONNECTION] },
+      { resource: Entity.BILLING, action: [Action.CHECK_CONNECTION, Action.CLEAR_BILLING_TEST_DATA] },
       { resource: Entity.TAXES, action: [Action.LIST], attributes: ['*'] },
       // ---------------------------------------------------------------------------------------------------
       // TODO - no use-case so far - clarify whether a SYNC INVOICES and CREATE INVOICE makes sense or not!

--- a/src/client/ocpp/soap/SoapChargingStationClient.ts
+++ b/src/client/ocpp/soap/SoapChargingStationClient.ts
@@ -367,7 +367,7 @@ export default class SoapChargingStationClient extends ChargingStationClient {
   }
 
   private getWSDLEndpointBaseUrl() {
-    return this.wsdlEndpointConfig?.baseUrl ? this.wsdlEndpointConfig.baseUrl : '';
+    return this.wsdlEndpointConfig?.baseUrl;
   }
 
   private initSoapHeaders(command: Command) {
@@ -379,6 +379,6 @@ export default class SoapChargingStationClient extends ChargingStationClient {
     this.client.addSoapHeader('<a:ReplyTo xmlns:a="http://www.w3.org/2005/08/addressing"><a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address></a:ReplyTo>');
     this.client.addSoapHeader(`<a:To xmlns:a="http://www.w3.org/2005/08/addressing">${this.chargingStation.chargingStationURL}</a:To>`);
     this.client.addSoapHeader(`<a:Action xmlns:a="http://www.w3.org/2005/08/addressing">/${command}</a:Action>`);
-    this.client.addSoapHeader(`<a:From xmlns:a="http://www.w3.org/2005/08/addressing"><a:Address>${this.getWSDLEndpointBaseSecureUrl() ? this.getWSDLEndpointBaseSecureUrl() : this.getWSDLEndpointBaseUrl()}</a:Address></a:From>`);
+    this.client.addSoapHeader(`<a:From xmlns:a="http://www.w3.org/2005/08/addressing"><a:Address>${this.getWSDLEndpointBaseSecureUrl() ?? (this.getWSDLEndpointBaseUrl() ?? '')}</a:Address></a:From>`);
   }
 }

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -371,7 +371,7 @@ export default abstract class BillingIntegration {
 
   // eslint-disable-next-line @typescript-eslint/member-ordering
   public async clearTestData(): Promise<void> {
-    await this.checkConnection();
+    // await this.checkConnection(); - stripe connection is useless to cleanup test data
     await Logging.logInfo({
       tenantID: this.tenant.id,
       source: Constants.CENTRAL_SERVER,
@@ -567,6 +567,10 @@ export default abstract class BillingIntegration {
   abstract checkConnection(): Promise<void>;
 
   abstract checkActivationPrerequisites(): Promise<void>;
+
+  abstract checkTestDataCleanupPrerequisites() : Promise<void>;
+
+  abstract resetConnectionSettings() : Promise<BillingSettings>;
 
   abstract startTransaction(transaction: Transaction): Promise<BillingDataTransactionStart>;
 

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -187,7 +187,7 @@ export default abstract class BillingIntegration {
     let skip = 0;
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const invoices = await BillingStorage.getInvoices(this.tenant.id, filter, { sort, limit, skip });
+      const invoices = await BillingStorage.getInvoices(this.tenant, filter, { sort, limit, skip });
       if (Utils.isEmptyArray(invoices.result)) {
         break;
       }
@@ -398,7 +398,7 @@ export default abstract class BillingIntegration {
   }
 
   private async _clearAllInvoiceTestData(): Promise<void> {
-    const invoices: DataResult<BillingInvoice> = await BillingStorage.getInvoices(this.tenant.id, { liveMode: false }, Constants.DB_PARAMS_MAX_LIMIT);
+    const invoices: DataResult<BillingInvoice> = await BillingStorage.getInvoices(this.tenant, { liveMode: false }, Constants.DB_PARAMS_MAX_LIMIT);
     // Let's now finalize all invoices and attempt to get it paid
     for (const invoice of invoices.result) {
       try {
@@ -436,7 +436,7 @@ export default abstract class BillingIntegration {
       });
     }
     await this._clearTransactionsTestData(billingInvoice);
-    await BillingStorage.deleteInvoice(this.tenant.id, billingInvoice.id);
+    await BillingStorage.deleteInvoice(this.tenant, billingInvoice.id);
   }
 
   private async _clearTransactionsTestData(billingInvoice: BillingInvoice): Promise<void> {

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -7,6 +7,7 @@ import { BillingSettings } from '../../types/Setting';
 import BillingStorage from '../../storage/mongodb/BillingStorage';
 import Constants from '../../utils/Constants';
 import { DataResult } from '../../types/DataResult';
+import Decimal from 'decimal.js';
 import Logging from '../../utils/Logging';
 import NotificationHandler from '../../notification/NotificationHandler';
 import { Request } from 'express';
@@ -238,29 +239,46 @@ export default abstract class BillingIntegration {
     return actionsDone;
   }
 
-  public async sendInvoiceNotification(billingInvoice: BillingInvoice): Promise<void> {
-    // Do not send notifications for invoices that are not yet finalized!
-    if (billingInvoice.status === BillingInvoiceStatus.OPEN || billingInvoice.status === BillingInvoiceStatus.PAID) {
-      // Send link to the user using our notification framework (link to the front-end + download)
-      const tenant = await TenantStorage.getTenant(this.tenant.id);
-      // Send async notification
-      await NotificationHandler.sendBillingNewInvoiceNotification(
-        this.tenant.id,
-        billingInvoice.id,
-        billingInvoice.user,
-        {
-          user: billingInvoice.user,
-          evseDashboardInvoiceURL: Utils.buildEvseBillingInvoicesURL(tenant.subdomain),
-          evseDashboardURL: Utils.buildEvseURL(tenant.subdomain),
-          invoiceDownloadUrl: Utils.buildEvseBillingDownloadInvoicesURL(tenant.subdomain, billingInvoice.id),
-          // Empty url allows to decide wether to display "pay" button in the email
-          payInvoiceUrl: billingInvoice.status === BillingInvoiceStatus.OPEN ? billingInvoice.payInvoiceUrl : '',
-          // Stripe saves amount in cents
-          invoiceAmount: Utils.createDecimal(billingInvoice.amount).div(100),
-          invoiceNumber: billingInvoice.number,
-          invoiceStatus: billingInvoice.status,
-        }
-      );
+  public async sendInvoiceNotification(billingInvoice: BillingInvoice): Promise<boolean> {
+    try {
+      // Do not send notifications for invoices that are not yet finalized!
+      if (billingInvoice.status === BillingInvoiceStatus.OPEN || billingInvoice.status === BillingInvoiceStatus.PAID) {
+        // Send link to the user using our notification framework (link to the front-end + download)
+        const tenant = await TenantStorage.getTenant(this.tenant.id);
+        // Stripe saves amount in cents
+        const decimInvoiceAmount = new Decimal(billingInvoice.amount).div(100);
+        // Format amunt with currency symbol depending on locale
+        const invoiceAmount = new Intl.NumberFormat(Utils.convertLocaleForCurrency(billingInvoice.user.locale), { style: 'currency', currency: billingInvoice.currency.toUpperCase() }).format(decimInvoiceAmount.toNumber());
+        // Send async notification
+        await NotificationHandler.sendBillingNewInvoiceNotification(
+          this.tenant.id,
+          billingInvoice.id,
+          billingInvoice.user,
+          {
+            user: billingInvoice.user,
+            evseDashboardInvoiceURL: Utils.buildEvseBillingInvoicesURL(tenant.subdomain),
+            evseDashboardURL: Utils.buildEvseURL(tenant.subdomain),
+            invoiceDownloadUrl: Utils.buildEvseBillingDownloadInvoicesURL(tenant.subdomain, billingInvoice.id),
+            // Empty url allows to decide wether to display "pay" button in the email
+            payInvoiceUrl: billingInvoice.status === BillingInvoiceStatus.OPEN ? billingInvoice.payInvoiceUrl : '',
+            invoiceAmount: invoiceAmount,
+            invoiceNumber: billingInvoice.number,
+            invoiceStatus: billingInvoice.status,
+          }
+        );
+        // Needed only for testing
+        return true;
+      }
+    } catch (error) {
+      await Logging.logError({
+        tenantID: this.tenant.id,
+        source: Constants.CENTRAL_SERVER,
+        action: ServerAction.BILLING_TRANSACTION,
+        module: MODULE_NAME, method: 'sendInvoiceNotification',
+        message: `Failed to send notification for invoice '${billingInvoice.id}'`,
+        detailedMessages: { error: error.message, stack: error.stack }
+      });
+      return false;
     }
   }
 

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -340,7 +340,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       }
     }
     // Get the corresponding BillingInvoice (if any)
-    const billingInvoice: BillingInvoice = await BillingStorage.getInvoiceByInvoiceID(this.tenant.id, stripeInvoice.id);
+    const billingInvoice: BillingInvoice = await BillingStorage.getInvoiceByInvoiceID(this.tenant, stripeInvoice.id);
     const invoiceToSave: BillingInvoice = {
       id: billingInvoice?.id, // ACHTUNG: billingInvoice is null when creating the Billing Invoice
       // eslint-disable-next-line id-blacklist
@@ -348,9 +348,9 @@ export default class StripeBillingIntegration extends BillingIntegration {
       status: status as BillingInvoiceStatus, payInvoiceUrl,
     };
     // Let's persist the up-to-date data
-    const freshInvoiceId = await BillingStorage.saveInvoice(this.tenant.id, invoiceToSave);
+    const freshInvoiceId = await BillingStorage.saveInvoice(this.tenant, invoiceToSave);
     // TODO - perf improvement? - can't we just reuse
-    const freshBillingInvoice = await BillingStorage.getInvoice(this.tenant.id, freshInvoiceId);
+    const freshBillingInvoice = await BillingStorage.getInvoice(this.tenant, freshInvoiceId);
     return freshBillingInvoice;
   }
 

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -317,8 +317,9 @@ export default class StripeBillingIntegration extends BillingIntegration {
     const stripeInvoiceID = stripeInvoice.id;
     // Destructuring the STRIPE invoice to extract the required information
     // eslint-disable-next-line id-blacklist, max-len
-    const { id: invoiceID, customer, number, livemode: liveMode, amount_due: amount, amount_paid: amountPaid, status, currency, invoice_pdf: downloadUrl, metadata, hosted_invoice_url: payInvoiceUrl } = stripeInvoice;
+    const { id: invoiceID, customer, number, livemode: liveMode, amount_due: amount, amount_paid: amountPaid, status, currency: invoiceCurrency, invoice_pdf: downloadUrl, metadata, hosted_invoice_url: payInvoiceUrl } = stripeInvoice;
     const customerID = customer as string;
+    const currency = invoiceCurrency?.toUpperCase();
     const createdOn = moment.unix(stripeInvoice.created).toDate(); // epoch to Date!
     // Check metadata consistency - userID is mandatory!
     const userID = metadata?.userID;

--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -1097,6 +1097,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
 
   public async billInvoiceItem(user: User, billingInvoiceItem: BillingInvoiceItem, idemPotencyKey?: string): Promise<BillingInvoice> {
     // Let's collect the required information
+    let refreshDataRequired = false;
     const userID: string = user.id;
     const customerID: string = user.billingData?.customerID;
     // Check whether a DRAFT invoice can be used
@@ -1140,6 +1141,9 @@ export default class StripeBillingIntegration extends BillingIntegration {
     if (!stripeInvoice) {
       // Let's create a new DRAFT invoice (if none has been found)
       stripeInvoice = await this._createStripeInvoice(customerID, userID, this.buildIdemPotencyKey(idemPotencyKey));
+    } else {
+      // Here an existing invoice is being reused
+      refreshDataRequired = true;
     }
     let operationResult: StripeChargeOperationResult;
     if (this.settings.billing?.immediateBillingAllowed) {
@@ -1160,9 +1164,13 @@ export default class StripeBillingIntegration extends BillingIntegration {
         // Reuse the operation result (for better performance)
         stripeInvoice = operationResult.invoice;
       } else {
-        // Get fresh data only when necessary - e.g.: invoice has been finalized, however the payment attempt failed
-        stripeInvoice = await this.getStripeInvoice(stripeInvoice.id);
+        // Something went wrong - we need to fetch the latest information from STRIPE again!
+        refreshDataRequired = true;
       }
+    }
+    // Get fresh data only when necessary - e.g.: invoice has been finalized, however the payment attempt failed
+    if (refreshDataRequired) {
+      stripeInvoice = await this.getStripeInvoice(stripeInvoice.id);
     }
     // Let's replicate some information on our side
     const billingInvoice = await this.synchronizeAsBillingInvoice(stripeInvoice, false);

--- a/src/integration/billing/stripe/StripeHelpers.ts
+++ b/src/integration/billing/stripe/StripeHelpers.ts
@@ -42,7 +42,7 @@ export default class StripeHelpers {
         session,
         lastError: billingError
       };
-      await BillingStorage.updateInvoiceAdditionalData(tenant.id, billingInvoice, additionalData);
+      await BillingStorage.updateInvoiceAdditionalData(tenant, billingInvoice, additionalData);
     }
   }
 

--- a/src/integration/charging-station-vendor/ChargingStationVendorFactory.ts
+++ b/src/integration/charging-station-vendor/ChargingStationVendorFactory.ts
@@ -14,7 +14,9 @@ import ExadysChargingStationVendorIntegration from './exadys/ExadysChargingStati
 import IESChargingStationVendorIntegration from './ies/IESChargingStationVendorIntegration';
 import IngeteamChargingStationVendorIntegration from './ingeteam/IngeteamChargingStationVendorIntegration';
 import InnogyChargingStationVendorIntegration from './innogy/InnogyChargingStationVendorIntegration';
+import JoinonChargingStationVendorIntegration from './joinon/JoinonChargingStationVendorIntegration';
 import KebaChargingStationVendorIntegration from './keba/KebaChargingStationVendorIntegration';
+import LafonChargingStationVendorIntegration from './lafon/LafonChargingStationVendorIntegration';
 import LegrandChargingStationVendorIntegration from './legrand/LegrandChargingStationVendorIntegration';
 import SAPLabsFranceChargingStationVendorIntegration from './sap/SAPLabsFranceChargingStationVendorIntegration';
 import SchneiderChargingStationVendorIntegration from './schneider/SchneiderChargingStationVendorIntegration';
@@ -64,6 +66,7 @@ export default class ChargingStationVendorFactory {
       case ChargerVendor.MENNEKES:
         chargingStationVendorImpl = new EbeeChargingStationVendorIntegration(chargingStation);
         break;
+      case ChargerVendor.DELTA_ELECTRONICS:
       case ChargerVendor.DELTA:
         chargingStationVendorImpl = new DeltaChargingStationVendorIntegration(chargingStation);
         break;
@@ -81,6 +84,12 @@ export default class ChargingStationVendorFactory {
         break;
       case ChargerVendor.CIRCONTROL:
         chargingStationVendorImpl = new CIRCONTROLChargingStationVendorIntegration(chargingStation);
+        break;
+      case ChargerVendor.JOINON:
+        chargingStationVendorImpl = new JoinonChargingStationVendorIntegration(chargingStation);
+        break;
+      case ChargerVendor.LAFON_TECHNOLOGIES:
+        chargingStationVendorImpl = new LafonChargingStationVendorIntegration(chargingStation);
         break;
     }
     return chargingStationVendorImpl;

--- a/src/integration/charging-station-vendor/joinon/JoinonChargingStationVendorIntegration.ts
+++ b/src/integration/charging-station-vendor/joinon/JoinonChargingStationVendorIntegration.ts
@@ -1,0 +1,8 @@
+import ChargingStation from '../../../types/ChargingStation';
+import ChargingStationVendorIntegration from '../ChargingStationVendorIntegration';
+
+export default class JoinonChargingStationVendorIntegration extends ChargingStationVendorIntegration {
+  constructor(chargingStation: ChargingStation) {
+    super(chargingStation);
+  }
+}

--- a/src/integration/charging-station-vendor/lafon/LafonChargingStationVendorIntegration.ts
+++ b/src/integration/charging-station-vendor/lafon/LafonChargingStationVendorIntegration.ts
@@ -1,0 +1,8 @@
+import ChargingStation from '../../../types/ChargingStation';
+import ChargingStationVendorIntegration from '../ChargingStationVendorIntegration';
+
+export default class LafonChargingStationVendorIntegration extends ChargingStationVendorIntegration {
+  constructor(chargingStation: ChargingStation) {
+    super(chargingStation);
+  }
+}

--- a/src/integration/smart-charging/SmartChargingIntegration.ts
+++ b/src/integration/smart-charging/SmartChargingIntegration.ts
@@ -43,6 +43,9 @@ export default abstract class SmartChargingIntegration<T extends SmartChargingSe
       });
       return;
     }
+    // Sort charging profiles
+    // Lower limits need to be set first. (When high limit is set first, it may appear that the corresponding low limit is not set yet)
+    chargingProfiles.sort((a, b) => a.profile.chargingSchedule.chargingSchedulePeriod[0].limit - b.profile.chargingSchedule.chargingSchedulePeriod[0].limit);
     // Apply the charging plans
     for (const chargingProfile of chargingProfiles) {
       try {

--- a/src/server/ocpp/json/JsonWSConnection.ts
+++ b/src/server/ocpp/json/JsonWSConnection.ts
@@ -64,9 +64,7 @@ export default class JsonWSConnection extends WSConnection {
         chargeBoxIdentity: this.getChargingStationID(),
         ocppVersion: (this.getWSConnection().protocol.startsWith('ocpp') ? this.getWSConnection().protocol.replace('ocpp', '') : this.getWSConnection().protocol) as OCPPVersion,
         ocppProtocol: OCPPProtocol.JSON,
-        chargingStationURL: Configuration.getJsonEndpointConfig().baseSecureUrl
-          ? Configuration.getJsonEndpointConfig().baseSecureUrl
-          : Configuration.getJsonEndpointConfig().baseUrl,
+        chargingStationURL: Configuration.getJsonEndpointConfig().baseSecureUrl ?? Configuration.getJsonEndpointConfig().baseUrl,
         tenantID: this.getTenantID(),
         token: this.getToken(),
         From: {

--- a/src/server/rest/v1/router/api/BillingRouter.ts
+++ b/src/server/rest/v1/router/api/BillingRouter.ts
@@ -18,6 +18,7 @@ export default class BillingRouter {
     this.buildRouteBillingSetting();
     this.buildRouteUpdateBillingSetting();
     this.buildRouteCheckBillingConnection();
+    this.buildRouteClearTestData();
     // -----------------------------------
     // ROUTES for PAYMENT METHODS
     // -----------------------------------
@@ -53,6 +54,12 @@ export default class BillingRouter {
   protected buildRouteCheckBillingConnection(): void {
     this.router.post(`/${ServerRoute.REST_BILLING_CHECK}`, (req: Request, res: Response, next: NextFunction) => {
       void RouterUtils.handleServerAction(BillingService.handleCheckBillingConnection.bind(this), ServerAction.SETTINGS, req, res, next);
+    });
+  }
+
+  protected buildRouteClearTestData(): void {
+    this.router.post(`/${ServerRoute.REST_BILLING_CLEAR_TEST_DATA}`, (req: Request, res: Response, next: NextFunction) => {
+      void RouterUtils.handleServerAction(BillingService.handleClearBillingTestData.bind(this), ServerAction.SETTINGS, req, res, next);
     });
   }
 

--- a/src/server/rest/v1/router/api/UserRouter.ts
+++ b/src/server/rest/v1/router/api/UserRouter.ts
@@ -21,6 +21,9 @@ export default class UserRouter {
     this.buildRouteUserDefaultCarTag();
     this.buildRouteUserGetSites();
     this.buildRouteUserSiteAssign();
+    this.buildRouteUserSiteUnassign();
+    this.buildRouteUserUpdateMobileToken();
+    this.buildRouteUserGetImage();
     return this.router;
   }
 
@@ -74,6 +77,26 @@ export default class UserRouter {
     this.router.post(`/${ServerRoute.REST_USER_SITES}`, async (req: Request, res: Response, next: NextFunction) => {
       req.body.userID = req.params.id;
       await RouterUtils.handleServerAction(UserService.handleAssignSitesToUser.bind(this), ServerAction.ADD_SITES_TO_USER, req, res, next);
+    });
+  }
+
+  protected buildRouteUserSiteUnassign(): void {
+    this.router.put(`/${ServerRoute.REST_USER_SITES}`, async (req: Request, res: Response, next: NextFunction) => {
+      req.body.userID = req.params.id;
+      await RouterUtils.handleServerAction(UserService.handleAssignSitesToUser.bind(this), ServerAction.REMOVE_SITES_FROM_USER, req, res, next);
+    });
+  }
+
+  protected buildRouteUserUpdateMobileToken(): void {
+    this.router.put(`/${ServerRoute.REST_USER_UPDATE_MOBILE_TOKEN}`, async (req: Request, res: Response, next: NextFunction) => {
+      await RouterUtils.handleServerAction(UserService.handleUpdateUserMobileToken.bind(this), ServerAction.USER_UPDATE_MOBILE_TOKEN, req, res, next);
+    });
+  }
+
+  protected buildRouteUserGetImage(): void {
+    this.router.get(`/${ServerRoute.REST_USER_IMAGE}`, async (req: Request, res: Response, next: NextFunction) => {
+      req.query.ID = req.params.id;
+      await RouterUtils.handleServerAction(UserService.handleGetUserImage.bind(this), ServerAction.USER_IMAGE, req, res, next);
     });
   }
 }

--- a/src/server/rest/v1/service/BillingService.ts
+++ b/src/server/rest/v1/service/BillingService.ts
@@ -334,7 +334,7 @@ export default class BillingService {
     // Filter
     const filteredRequest = BillingSecurity.filterGetInvoicesRequest(req.query);
     // Get invoices
-    const invoices = await BillingStorage.getInvoices(req.user.tenantID,
+    const invoices = await BillingStorage.getInvoices(req.tenant,
       {
         userIDs: !Authorizations.isAdmin(req.user) ? [req.user.id] : (filteredRequest.UserID ? filteredRequest.UserID.split('|') : null),
         invoiceStatus: filteredRequest.Status ? filteredRequest.Status.split('|') as BillingInvoiceStatus[] : null,
@@ -370,7 +370,7 @@ export default class BillingService {
       userProject = [ 'userID', 'user.id', 'user.name', 'user.firstName', 'user.email' ];
     }
     // Get invoice
-    const invoice = await BillingStorage.getInvoice(req.user.tenantID, filteredRequest.ID,
+    const invoice = await BillingStorage.getInvoice(req.tenant, filteredRequest.ID,
       [
         'id', 'number', 'status', 'amount', 'createdOn', 'currency', 'downloadable', 'sessions',
         ...userProject
@@ -700,7 +700,7 @@ export default class BillingService {
     // Filter
     const filteredRequest = BillingSecurity.filterDownloadInvoiceRequest(req.query);
     // Get the Invoice
-    const billingInvoice = await BillingStorage.getInvoice(req.user.tenantID, filteredRequest.ID);
+    const billingInvoice = await BillingStorage.getInvoice(req.tenant, filteredRequest.ID);
     UtilsService.assertObjectExists(action, billingInvoice, `Invoice ID '${filteredRequest.ID}' does not exist`,
       MODULE_NAME, 'handleDownloadInvoice', req.user);
     // Check Auth

--- a/src/server/rest/v1/service/ConnectionService.ts
+++ b/src/server/rest/v1/service/ConnectionService.ts
@@ -13,6 +13,7 @@ import Logging from '../../../../utils/Logging';
 import RefundFactory from '../../../../integration/refund/RefundFactory';
 import { ServerAction } from '../../../../types/Server';
 import { StatusCodes } from 'http-status-codes';
+import TenantStorage from '../../../../storage/mongodb/TenantStorage';
 import UtilsService from './UtilsService';
 
 const MODULE_NAME = 'ConnectionService';
@@ -47,7 +48,7 @@ export default class ConnectionService {
       userProject = [ 'createdBy.name', 'createdBy.firstName', 'lastChangedBy.name', 'lastChangedBy.firstName' ];
     }
     // Get it
-    const connection = await ConnectionStorage.getConnection(req.user.tenantID, connectionID,
+    const connection = await ConnectionStorage.getConnection(req.tenant, connectionID,
       [ 'id', 'connectorId', 'createdAt', 'validUntil', 'lastChangedOn', 'createdOn', ...userProject ]);
     UtilsService.assertObjectExists(action, connection, `Connection ID '${connectionID}' does not exist`,
       MODULE_NAME, 'handleGetConnection', req.user);
@@ -73,7 +74,7 @@ export default class ConnectionService {
       userProject = [ 'createdBy.name', 'createdBy.firstName', 'lastChangedBy.name', 'lastChangedBy.firstName' ];
     }
     // Get
-    const connections = await ConnectionStorage.getConnectionsByUserId(req.user.tenantID, filteredRequest.UserID,
+    const connections = await ConnectionStorage.getConnectionsByUserId(req.tenant, filteredRequest.UserID,
       [ 'id', 'connectorId', 'createdAt', 'validUntil', 'lastChangedOn', 'createdOn', ...userProject ]);
     res.json(connections);
     next();
@@ -106,7 +107,7 @@ export default class ConnectionService {
       detailedMessages: { connection }
     });
     // Ok
-    res.status(StatusCodes.OK).json(Object.assign({ id: req.user.tenantID }, Constants.REST_RESPONSE_SUCCESS));
+    res.status(StatusCodes.OK).json(Object.assign({ id: req.tenant.id }, Constants.REST_RESPONSE_SUCCESS));
     next();
   }
 
@@ -123,11 +124,11 @@ export default class ConnectionService {
       });
     }
     // Get connection
-    const connection = await ConnectionStorage.getConnection(req.user.tenantID, connectionID);
+    const connection = await ConnectionStorage.getConnection(req.tenant, connectionID);
     UtilsService.assertObjectExists(action, connection, `Connection ID '${connectionID}' does not exist`,
       MODULE_NAME, 'handleDeleteConnection', req.user);
     // Delete
-    await ConnectionStorage.deleteConnectionById(req.user.tenantID, connection.id);
+    await ConnectionStorage.deleteConnectionById(req.tenant, connection.id);
     // Log
     await Logging.logSecurityInfo({
       tenantID: req.user.tenantID,

--- a/src/server/rest/v1/service/UserService.ts
+++ b/src/server/rest/v1/service/UserService.ts
@@ -531,7 +531,7 @@ export default class UserService {
 
   public static async handleUpdateUserMobileToken(action: ServerAction, req: Request, res: Response, next: NextFunction): Promise<void> {
     // Filter
-    const filteredRequest = UserSecurity.filterUserUpdateMobileTokenRequest(req.body);
+    const filteredRequest = UserSecurity.filterUserUpdateMobileTokenRequest({ ...req.params, ...req.body });
     // Check Mandatory fields
     if (!filteredRequest.mobileToken) {
       throw new AppError({

--- a/src/storage/mongodb/BillingStorage.ts
+++ b/src/storage/mongodb/BillingStorage.ts
@@ -7,35 +7,36 @@ import DatabaseUtils from './DatabaseUtils';
 import DbParams from '../../types/database/DbParams';
 import Logging from '../../utils/Logging';
 import { ObjectID } from 'mongodb';
+import Tenant from '../../types/Tenant';
 import Utils from '../../utils/Utils';
 
 const MODULE_NAME = 'BillingStorage';
 
 export default class BillingStorage {
-  public static async getInvoice(tenantID: string, id: string = Constants.UNKNOWN_OBJECT_ID, projectFields?: string[]): Promise<BillingInvoice> {
-    const invoicesMDB = await BillingStorage.getInvoices(tenantID, {
+  public static async getInvoice(tenant: Tenant, id: string = Constants.UNKNOWN_OBJECT_ID, projectFields?: string[]): Promise<BillingInvoice> {
+    const invoicesMDB = await BillingStorage.getInvoices(tenant, {
       invoiceIDs: [id]
     }, Constants.DB_PARAMS_SINGLE_RECORD, projectFields);
     return invoicesMDB.count === 1 ? invoicesMDB.result[0] : null;
   }
 
-  public static async getInvoiceByInvoiceID(tenantID: string, id: string): Promise<BillingInvoice> {
-    const invoicesMDB = await BillingStorage.getInvoices(tenantID, {
+  public static async getInvoiceByInvoiceID(tenant: Tenant, id: string): Promise<BillingInvoice> {
+    const invoicesMDB = await BillingStorage.getInvoices(tenant, {
       billingInvoiceID: id
     }, Constants.DB_PARAMS_SINGLE_RECORD);
     return invoicesMDB.count === 1 ? invoicesMDB.result[0] : null;
   }
 
-  public static async getInvoices(tenantID: string,
+  public static async getInvoices(tenant: Tenant,
       params: {
         invoiceIDs?: string[]; billingInvoiceID?: string; search?: string; userIDs?: string[]; invoiceStatus?: BillingInvoiceStatus[];
         startDateTime?: Date; endDateTime?: Date; liveMode?: boolean
       } = {},
       dbParams: DbParams, projectFields?: string[]): Promise<DataResult<BillingInvoice>> {
     // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'getInvoices');
+    const uniqueTimerID = Logging.traceStart(tenant.id, MODULE_NAME, 'getInvoices');
     // Check Tenant
-    await DatabaseUtils.checkTenant(tenantID);
+    DatabaseUtils.checkTenantObject(tenant);
     // Clone before updating the values
     dbParams = Utils.cloneObject(dbParams);
     // Check Limit
@@ -98,12 +99,12 @@ export default class BillingStorage {
       aggregation.push({ $limit: Constants.DB_RECORD_COUNT_CEIL });
     }
     // Count Records
-    const invoicesCountMDB = await global.database.getCollection<any>(tenantID, 'invoices')
+    const invoicesCountMDB = await global.database.getCollection<any>(tenant.id, 'invoices')
       .aggregate([...aggregation, { $count: 'count' }], { allowDiskUse: true })
       .toArray();
     // Check if only the total count is requested
     if (dbParams.onlyRecordCount) {
-      await Logging.traceEnd(tenantID, MODULE_NAME, 'getInvoices', uniqueTimerID, invoicesCountMDB);
+      await Logging.traceEnd(tenant.id, MODULE_NAME, 'getInvoices', uniqueTimerID, invoicesCountMDB);
       return {
         count: (invoicesCountMDB.length > 0 ? invoicesCountMDB[0].count : 0),
         result: []
@@ -128,11 +129,11 @@ export default class BillingStorage {
     });
     // Add Users
     DatabaseUtils.pushUserLookupInAggregation({
-      tenantID, aggregation: aggregation, asField: 'user', localField: 'userID',
+      tenantID: tenant.id, aggregation: aggregation, asField: 'user', localField: 'userID',
       foreignField: '_id', oneToOneCardinality: true, oneToOneCardinalityNotNull: false
     });
     // Add Last Changed / Created
-    DatabaseUtils.pushCreatedLastChangedInAggregation(tenantID, aggregation);
+    DatabaseUtils.pushCreatedLastChangedInAggregation(tenant.id, aggregation);
     // Handle the ID
     DatabaseUtils.pushRenameDatabaseID(aggregation);
     // Convert Object ID to string
@@ -140,13 +141,13 @@ export default class BillingStorage {
     // Project
     DatabaseUtils.projectFields(aggregation, projectFields);
     // Read DB
-    const invoicesMDB = await global.database.getCollection<BillingInvoice>(tenantID, 'invoices')
+    const invoicesMDB = await global.database.getCollection<BillingInvoice>(tenant.id, 'invoices')
       .aggregate(aggregation, {
         allowDiskUse: true
       })
       .toArray();
     // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'getInvoices', uniqueTimerID, invoicesMDB);
+    await Logging.traceEnd(tenant.id, MODULE_NAME, 'getInvoices', uniqueTimerID, invoicesMDB);
     return {
       count: (invoicesCountMDB.length > 0 ?
         (invoicesCountMDB[0].count === Constants.DB_RECORD_COUNT_CEIL ? -1 : invoicesCountMDB[0].count) : 0),
@@ -154,9 +155,9 @@ export default class BillingStorage {
     };
   }
 
-  public static async saveInvoice(tenantID: string, invoiceToSave: BillingInvoice): Promise<string> {
+  public static async saveInvoice(tenant: Tenant, invoiceToSave: BillingInvoice): Promise<string> {
     // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'saveInvoice');
+    const uniqueTimerID = Logging.traceStart(tenant.id, MODULE_NAME, 'saveInvoice');
     // Build Request
     // Properties to save
     const invoiceMDB: any = {
@@ -177,21 +178,21 @@ export default class BillingStorage {
       payInvoiceUrl: invoiceToSave.payInvoiceUrl
     };
     // Modify and return the modified document
-    await global.database.getCollection<BillingInvoice>(tenantID, 'invoices').findOneAndUpdate(
+    await global.database.getCollection<BillingInvoice>(tenant.id, 'invoices').findOneAndUpdate(
       { _id: invoiceMDB._id },
       { $set: invoiceMDB },
       { upsert: true, returnDocument: 'after' }
     );
     // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'saveInvoice', uniqueTimerID, invoiceMDB);
+    await Logging.traceEnd(tenant.id, MODULE_NAME, 'saveInvoice', uniqueTimerID, invoiceMDB);
     return invoiceMDB._id.toHexString();
   }
 
-  public static async updateInvoiceAdditionalData(tenantID: string, invoiceToUpdate: BillingInvoice, additionalData: BillingAdditionalData): Promise<void> {
+  public static async updateInvoiceAdditionalData(tenant: Tenant, invoiceToUpdate: BillingInvoice, additionalData: BillingAdditionalData): Promise<void> {
     // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'saveInvoiceAdditionalData');
+    const uniqueTimerID = Logging.traceStart(tenant.id, MODULE_NAME, 'saveInvoiceAdditionalData');
     // Check Tenant
-    await DatabaseUtils.checkTenant(tenantID);
+    DatabaseUtils.checkTenantObject(tenant);
     // Preserve the previous list of sessions
     const sessions: BillingSessionData[] = invoiceToUpdate.sessions || [];
     if (additionalData.session) {
@@ -202,34 +203,34 @@ export default class BillingStorage {
       sessions,
       lastError: additionalData.lastError
     };
-    await global.database.getCollection(tenantID, 'invoices').findOneAndUpdate(
+    await global.database.getCollection(tenant.id, 'invoices').findOneAndUpdate(
       { '_id': Utils.convertToObjectID(invoiceToUpdate.id) },
       { $set: updatedInvoiceMDB });
     // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'saveInvoiceAdditionalData', uniqueTimerID, updatedInvoiceMDB);
+    await Logging.traceEnd(tenant.id, MODULE_NAME, 'saveInvoiceAdditionalData', uniqueTimerID, updatedInvoiceMDB);
   }
 
-  public static async deleteInvoice(tenantID: string, id: string): Promise<void> {
+  public static async deleteInvoice(tenant: Tenant, id: string): Promise<void> {
     // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'deleteInvoice');
+    const uniqueTimerID = Logging.traceStart(tenant.id, MODULE_NAME, 'deleteInvoice');
     // Check Tenant
-    await DatabaseUtils.checkTenant(tenantID);
+    DatabaseUtils.checkTenantObject(tenant);
     // Delete the Invoice
-    await global.database.getCollection<BillingInvoice>(tenantID, 'invoices')
+    await global.database.getCollection<BillingInvoice>(tenant.id, 'invoices')
       .findOneAndDelete({ '_id': Utils.convertToObjectID(id) });
     // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'deleteInvoice', uniqueTimerID, { id });
+    await Logging.traceEnd(tenant.id, MODULE_NAME, 'deleteInvoice', uniqueTimerID, { id });
   }
 
-  public static async deleteInvoiceByInvoiceID(tenantID: string, id: string): Promise<void> {
+  public static async deleteInvoiceByInvoiceID(tenant: Tenant, id: string): Promise<void> {
     // Debug
-    const uniqueTimerID = Logging.traceStart(tenantID, MODULE_NAME, 'deleteInvoice');
+    const uniqueTimerID = Logging.traceStart(tenant.id, MODULE_NAME, 'deleteInvoice');
     // Check Tenant
-    await DatabaseUtils.checkTenant(tenantID);
+    DatabaseUtils.checkTenantObject(tenant);
     // Delete the Invoice
-    await global.database.getCollection<BillingInvoice>(tenantID, 'invoices')
+    await global.database.getCollection<BillingInvoice>(tenant.id, 'invoices')
       .findOneAndDelete({ 'invoiceID': id });
     // Debug
-    await Logging.traceEnd(tenantID, MODULE_NAME, 'deleteInvoice', uniqueTimerID, { id });
+    await Logging.traceEnd(tenant.id, MODULE_NAME, 'deleteInvoice', uniqueTimerID, { id });
   }
 }

--- a/src/storage/mongodb/CompanyStorage.ts
+++ b/src/storage/mongodb/CompanyStorage.ts
@@ -217,7 +217,8 @@ export default class CompanyStorage {
     return {
       count: (companiesCountMDB.length > 0 ?
         (companiesCountMDB[0].count === Constants.DB_RECORD_COUNT_CEIL ? -1 : companiesCountMDB[0].count) : 0),
-      result: companiesMDB
+      result: companiesMDB,
+      projectedFields: projectFields
     };
   }
 

--- a/src/storage/mongodb/SiteAreaStorage.ts
+++ b/src/storage/mongodb/SiteAreaStorage.ts
@@ -316,6 +316,7 @@ export default class SiteAreaStorage {
     await Logging.traceEnd(tenantID, MODULE_NAME, 'getSiteAreas', uniqueTimerID, siteAreasMDB);
     // Ok
     return {
+      projectedFields: projectFields,
       count: (siteAreasCountMDB.length > 0 ?
         (siteAreasCountMDB[0].count === Constants.DB_RECORD_COUNT_CEIL ? -1 : siteAreasCountMDB[0].count) : 0),
       result: siteAreas

--- a/src/storage/mongodb/SiteStorage.ts
+++ b/src/storage/mongodb/SiteStorage.ts
@@ -490,6 +490,7 @@ export default class SiteStorage {
     // Debug
     await Logging.traceEnd(tenantID, MODULE_NAME, 'getSites', uniqueTimerID, sites);
     return {
+      projectedFields: projectFields,
       count: (sitesCountMDB.length > 0 ?
         (sitesCountMDB[0].count === Constants.DB_RECORD_COUNT_CEIL ? -1 : sitesCountMDB[0].count) : 0),
       result: sites

--- a/src/types/Authorization.ts
+++ b/src/types/Authorization.ts
@@ -142,6 +142,7 @@ export enum Action {
   BILLING_DELETE_PAYMENT_METHOD = 'BillingDeletePaymentMethod',
   BILLING_CHARGE_INVOICE = 'BillingChargeInvoice',
   CHECK_CONNECTION = 'CheckConnection',
+  CLEAR_BILLING_TEST_DATA = 'ClearBillingTestData',
   RETRIEVE_CONSUMPTION = 'RetrieveConsumption',
   PING = 'Ping',
   GENERATE_LOCAL_TOKEN = 'GenerateLocalToken',

--- a/src/types/ChargingStation.ts
+++ b/src/types/ChargingStation.ts
@@ -312,6 +312,7 @@ export enum ChargerVendor {
   WALLBOX_CHARGERS = 'Wall Box Chargers',
   SCHNEIDER = 'Schneider Electric',
   WEBASTO = 'Webasto',
+  DELTA_ELECTRONICS = 'Delta Electronics',
   DELTA = 'DELTA',
   ABB = 'ABB',
   LEGRAND = 'Legrand',
@@ -320,4 +321,6 @@ export enum ChargerVendor {
   KEBA = 'Keba AG',
   SAP_LABS_FRANCE = 'SAP Labs France Caen',
   CIRCONTROL = 'CIRCONTROL',
+  JOINON = 'JOINON',
+  LAFON_TECHNOLOGIES = 'LAFON TECHNOLOGIES'
 }

--- a/src/types/DataResult.ts
+++ b/src/types/DataResult.ts
@@ -9,6 +9,7 @@ import { Transaction } from '@google-cloud/firestore';
 export interface DataResult<T> {
   count: number;
   result: T[];
+  projectedFields?: string[];
 }
 
 export interface CompanyDataResult extends DataResult<Company>{

--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -519,6 +519,7 @@ export enum ServerRoute {
 
   REST_BILLING_SETTING = 'billing-setting', // GET and PUT
   REST_BILLING_CHECK = 'billing/check',
+  REST_BILLING_CLEAR_TEST_DATA = 'billing/clearTestData',
 
   // BILLING URLs for CRUD operations on INVOICES
   REST_BILLING_INVOICES = 'invoices',

--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -498,6 +498,8 @@ export enum ServerRoute {
   REST_USER = 'users/:id',
   REST_USER_DEFAULT_TAG_CAR = 'users/:id/default-car-tag',
   REST_USER_SITES = 'users/:id/sites',
+  REST_USER_UPDATE_MOBILE_TOKEN = 'users/:id/mobile-token',
+  REST_USER_IMAGE = 'users/:id/image',
 
   REST_TAGS = 'tags',
   REST_TAG = 'tags/:id',

--- a/src/types/UserNotifications.ts
+++ b/src/types/UserNotifications.ts
@@ -278,7 +278,7 @@ export interface BillingNewInvoiceNotification extends BaseNotification {
   invoiceDownloadUrl: string;
   payInvoiceUrl: string;
   invoiceNumber: string;
-  invoiceAmount: Decimal;
+  invoiceAmount: string;
   invoiceStatus: string;
 }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -353,6 +353,10 @@ export default class Utils {
     return Constants.DEFAULT_LOCALE;
   }
 
+  public static convertLocaleForCurrency(locale: string): string {
+    return locale.replace('_', '-');
+  }
+
   public static getConnectorLimitSourceString(limitSource: ConnectorCurrentLimitSource): string {
     switch (limitSource) {
       case ConnectorCurrentLimitSource.CHARGING_PROFILE:

--- a/test/api/BillingStripeTestData.ts
+++ b/test/api/BillingStripeTestData.ts
@@ -275,7 +275,7 @@ export default class StripeIntegrationTestData {
 
   public async payDraftInvoice(draftInvoice: { id: string }, paymentShouldFail: boolean): Promise<void> {
     const draftInvoiceId = draftInvoice.id;
-    let billingInvoice: BillingInvoice = await BillingStorage.getInvoice(this.getTenantID(), draftInvoiceId);
+    let billingInvoice: BillingInvoice = await BillingStorage.getInvoice(this.tenantContext?.getTenant(), draftInvoiceId);
     // Let's attempt a payment using the default payment method
     billingInvoice = await this.billingImpl.chargeInvoice(billingInvoice);
     if (paymentShouldFail) {

--- a/test/api/BillingStripeTestData.ts
+++ b/test/api/BillingStripeTestData.ts
@@ -65,7 +65,7 @@ export default class StripeIntegrationTestData {
 
   public async forceBillingSettings(immediateBilling: boolean): Promise<void> {
     // The tests requires some settings to be forced
-    this.billingImpl = await this.setBillingSystemValidCredentials(immediateBilling);
+    await this.setBillingSystemValidCredentials(immediateBilling);
     this.billingUser = await this.billingImpl.getUser(this.dynamicUser);
     if (!this.billingUser && !FeatureToggles.isFeatureActive(Feature.BILLING_SYNC_USER)) {
       this.billingUser = await this.billingImpl.forceSynchronizeUser(this.dynamicUser);
@@ -73,10 +73,20 @@ export default class StripeIntegrationTestData {
     assert(this.billingUser, 'Billing user should not be null');
   }
 
-  public async setBillingSystemValidCredentials(immediateBilling: boolean) : Promise<StripeBillingIntegration> {
+  public async setBillingSystemValidCredentials(immediateBilling: boolean) : Promise<void> {
     const billingSettings = this.getLocalSettings(immediateBilling);
     await this.saveBillingSettings(billingSettings);
     billingSettings.stripe.secretKey = await Cypher.encrypt(this.getTenantID(), billingSettings.stripe.secretKey);
+    this.billingImpl = StripeBillingIntegration.getInstance(this.getTenant(), billingSettings);
+    assert(this.billingImpl, 'Billing implementation should not be null');
+  }
+
+  public async fakeLiveBillingSettings() : Promise<StripeBillingIntegration> {
+    const billingSettings = this.getLocalSettings(true);
+    const mode = 'live';
+    billingSettings.stripe.secretKey = `sk_${mode}_0234567890`;
+    billingSettings.stripe.publicKey = `pk_${mode}_0234567890`;
+    await this.saveBillingSettings(billingSettings);
     const billingImpl = StripeBillingIntegration.getInstance(this.getTenant(), billingSettings);
     assert(billingImpl, 'Billing implementation should not be null');
     return billingImpl;
@@ -366,9 +376,28 @@ export default class StripeIntegrationTestData {
     expect(corruptedBillingData.customerID).to.not.be.eq(billingUser.billingData.customerID);
   }
 
-  public async checkTestDataCleanup(): Promise<void> {
-    await this.billingImpl.clearTestData();
-    await this.checkNoInvoices();
-    await this.checkNoUsersWithTestData();
+  public async checkTestDataCleanup(successExpected: boolean): Promise<void> {
+    // await this.billingImpl.clearTestData();
+    const response = await this.adminUserService.billingApi.clearBillingTestData();
+    if (successExpected) {
+      // Check the response
+      assert(response?.data?.succeeded === true, 'The operation should succeed');
+      assert(!response?.data?.error, 'error should not be set');
+      assert(response?.data?.internalData, 'internalData should provide the new settings');
+      // Check the new billing settings
+      const newSettings: BillingSettings = response?.data?.internalData as BillingSettings;
+      assert(newSettings.billing.isTransactionBillingActivated === false, 'Transaction billing should be switched OFF');
+      assert(!newSettings.billing.taxID, 'taxID should not be set anymore');
+      assert(!newSettings.stripe.url, 'URL should not be set anymore');
+      assert(!newSettings.stripe.publicKey, 'publicKey should not be set anymore');
+      assert(!newSettings.stripe.secretKey, 'secretKey should not be set anymore');
+      // Check the invoices
+      await this.checkNoInvoices();
+      // Check the users
+      await this.checkNoUsersWithTestData();
+    } else {
+      assert(response?.data?.succeeded === false, 'The operation should fail');
+      assert(response?.data?.error, 'error should not be null');
+    }
   }
 }

--- a/test/api/BillingTestDataCleanupTest.ts
+++ b/test/api/BillingTestDataCleanupTest.ts
@@ -21,16 +21,26 @@ describe('Billing Test Data Cleanup', function() {
       global.database = new MongoDBStorage(config.get('storage'));
       await global.database.start();
       await testData.initialize();
-      await testData.forceBillingSettings(true);
     });
 
-    after(async () => {
-      // Cleanup of the utbilling tenant is useless
-      // Anyway, there is no way to cleanup the utbilling stripe account!
+    describe('with a STRIPE live account (a fake one!)', () => {
+      before(async () => {
+        await testData.fakeLiveBillingSettings();
+      });
+
+      it('should NOT cleanup all billing test data', async () => {
+        await testData.checkTestDataCleanup(false);
+      });
     });
 
-    it('should cleanup all billing test data', async () => {
-      await testData.checkTestDataCleanup();
+    describe('with a STRIPE test account', () => {
+      before(async () => {
+        await testData.setBillingSystemValidCredentials(true);
+      });
+
+      it('should cleanup all billing test data', async () => {
+        await testData.checkTestDataCleanup(true);
+      });
     });
   });
 

--- a/test/api/SiteOrgTest.ts
+++ b/test/api/SiteOrgTest.ts
@@ -27,9 +27,6 @@ class TestData {
 
 const testData: TestData = new TestData();
 
-/**
- * @param userRole
- */
 function login(userRole) {
   testData.userContext = testData.tenantContext.getUserContext(userRole);
   if (testData.userContext === testData.centralUserContext) {
@@ -43,9 +40,6 @@ function login(userRole) {
   }
 }
 
-/**
- *
- */
 async function createSite() {
   // Create a site
   testData.newSite = await testData.userService.createEntity(
@@ -55,30 +49,25 @@ async function createSite() {
   testData.createdSites.push(testData.newSite);
 }
 
-/**
- * @param userRole
- * @param site
- */
 async function assignUserToSite(userRole, site): Promise<any> {
   // Assign the user to the site
   const userContext = await testData.tenantContext.getUserContext(userRole);
   return testData.userService.siteApi.addUsersToSite(site.id, [userContext.id]);
 }
 
-/**
- * @param userRole
- * @param sites
- */
+
 async function assignSitesToUser(userRole, sites: string[]): Promise<any> {
   // Assign the user to the site
   const userContext = await testData.tenantContext.getUserContext(userRole);
   return testData.userService.siteApi.addSitesToUser(userContext.id, sites);
 }
 
-/**
- * @param userRole
- * @param site
- */
+async function unassignSitesToUser(userRole, sites: string[]): Promise<any> {
+  // Assign the user to the site
+  const userContext = await testData.tenantContext.getUserContext(userRole);
+  return testData.userService.siteApi.unassignSitesToUser(userContext.id, sites);
+}
+
 async function assignSiteAdmin(userRole, site) {
   // Assign the user as admin to the site
   const userContext = await testData.tenantContext.getUserContext(userRole);
@@ -86,10 +75,6 @@ async function assignSiteAdmin(userRole, site) {
   await testData.userService.siteApi.assignSiteAdmin(site.id, userContext.id);
 }
 
-/**
- * @param userRole
- * @param site
- */
 async function assignSiteOwner(userRole, site) {
   // Assign the user as owner to the site
   const userContext = await testData.tenantContext.getUserContext(userRole);
@@ -182,8 +167,16 @@ describe('Site tests', function() {
         expect(res.data.result.map((site) => site.user.id)).to.contain(userContext.id);
       });
 
+      it('Should be able to unassign a site to a user', async () => {
+        await unassignSitesToUser(ContextDefinition.USER_CONTEXTS.BASIC_USER, [testData.newSite.id]);
+        const res = await testData.userService.siteApi.readUsersForSite(testData.newSite.id);
+        expect(res.data.count).to.eq(0);
+        const userContext = await testData.tenantContext.getUserContext(ContextDefinition.USER_CONTEXTS.BASIC_USER);
+        expect(res.data.result.map((site) => site.user.id)).to.not.contain(userContext.id);
+      });
+
       it('Should be able to assign a site to a user', async () => {
-        await assignSitesToUser(ContextDefinition.USER_CONTEXTS.BASIC_USER, [testData.newSite]);
+        await assignSitesToUser(ContextDefinition.USER_CONTEXTS.BASIC_USER, [testData.newSite.id]);
         const res = await testData.userService.siteApi.readUsersForSite(testData.newSite.id);
         expect(res.data.count).to.eq(1);
         const userContext = await testData.tenantContext.getUserContext(ContextDefinition.USER_CONTEXTS.BASIC_USER);

--- a/test/api/UserTest.ts
+++ b/test/api/UserTest.ts
@@ -2,6 +2,7 @@ import chai, { assert, expect } from 'chai';
 
 import CentralServerService from '../api/client/CentralServerService';
 import ChargingStationContext from './context/ChargingStationContext';
+import Constants from '../../src/utils/Constants';
 import ContextDefinition from './context/ContextDefinition';
 import ContextProvider from './context/ContextProvider';
 import Factory from '../factories/Factory';
@@ -238,6 +239,23 @@ describe('User tests', function() {
           expect(updatedUser.name).to.equal(testData.newUser.name);
         });
 
+        it('Should update user\'s mobile token', async () => {
+          const response = await testData.userService.userApi.updateMobileToken(
+            testData.newUser.id,
+            'new_mobile_token',
+            'mobile_os'
+          );
+          expect(response.status).to.be.eq(StatusCodes.OK);
+          expect(response.data).to.be.deep.eq(Constants.REST_RESPONSE_SUCCESS);
+        });
+
+        it('Should get user image', async () => {
+          const response = await testData.userService.userApi.getImage(testData.newUser.id);
+          expect(response.status).to.be.eq(StatusCodes.OK);
+          expect(response.data.id).to.be.eq(testData.newUser.id);
+          expect(response.data.image).to.be.null; // New users have a null image
+        });
+
         it('Should be able to delete the created user', async () => {
           // Delete the created entity
           await testData.userService.deleteEntity(
@@ -253,7 +271,6 @@ describe('User tests', function() {
             testData.newUser
           );
         });
-
       });
       describe('Using function "readAllInError"', () => {
 

--- a/test/api/client/BillingApi.ts
+++ b/test/api/client/BillingApi.ts
@@ -40,6 +40,10 @@ export default class BillingApi extends CrudApi {
     return await super.create(params, super.buildRestEndpointUrl(ServerRoute.REST_BILLING_CHECK, params));
   }
 
+  public async clearBillingTestData(params?) {
+    return await super.create(params, super.buildRestEndpointUrl(ServerRoute.REST_BILLING_CLEAR_TEST_DATA, params));
+  }
+
   public async updateBillingSetting(params?) {
     return await super.update(params, super.buildRestEndpointUrl(ServerRoute.REST_BILLING_SETTING, params));
   }

--- a/test/api/client/SiteApi.ts
+++ b/test/api/client/SiteApi.ts
@@ -42,6 +42,13 @@ export default class SiteApi extends CrudApi {
     }, url);
   }
 
+  public async unassignSitesToUser(userId: string, siteIds: string[]) {
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_USER_SITES, { id: userId });
+    return super.update({
+      siteIDs: siteIds,
+    }, url);
+  }
+
   public async readUsersForSite(siteId) {
     return super.read({
       SiteID: siteId

--- a/test/api/client/UserApi.ts
+++ b/test/api/client/UserApi.ts
@@ -1,4 +1,5 @@
 import CrudApi from './utils/CrudApi';
+import { ServerRoute } from '../../../src/types/Server';
 import TestConstants from './utils/TestConstants';
 
 export default class UserApi extends CrudApi {
@@ -7,11 +8,12 @@ export default class UserApi extends CrudApi {
   }
 
   public async readById(id) {
-    return super.readById(id, '/client/api/User');
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_USER, { id });
+    return super.readById(id, url);
   }
 
   public async readAll(params, paging = TestConstants.DEFAULT_PAGING, ordering = TestConstants.DEFAULT_ORDERING) {
-    return super.readAll(params, paging, ordering, '/client/api/Users');
+    return super.readAll(params, paging, ordering, this.buildRestEndpointUrl(ServerRoute.REST_USERS));
   }
 
   public async readAllInError(params, paging = TestConstants.DEFAULT_PAGING, ordering = TestConstants.DEFAULT_ORDERING) {
@@ -19,15 +21,18 @@ export default class UserApi extends CrudApi {
   }
 
   public async create(data) {
-    return super.create(data, '/client/api/UserCreate');
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_USERS);
+    return super.create(data, url);
   }
 
   public async update(data) {
-    return super.update(data, '/client/api/UserUpdate');
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_USER, { id: data.id });
+    return super.update(data, url);
   }
 
   public async delete(id) {
-    return super.delete(id, '/client/api/UserDelete');
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_USER, { id });
+    return super.delete(id, url);
   }
 
   public async getByEmail(email) {
@@ -56,5 +61,17 @@ export default class UserApi extends CrudApi {
 
   public async exportTags(params) {
     return await super.read(params, '/client/api/TagsExport');
+  }
+
+  public async updateMobileToken(userID: string, mobileToken: string, mobileOS: string) {
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_USER_UPDATE_MOBILE_TOKEN, { id: userID });
+    return await super.update({
+      mobileToken, mobileOS
+    }, url);
+  }
+
+  public async getImage(userID: string) {
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_USER_IMAGE, { id: userID });
+    return await super.read({}, url);
   }
 }


### PR DESCRIPTION
Changing tenant Id to object in Connection Storage to reduce number of DB calls to check tenant.