### PR TITLE
Smart Charging > Sort charging profiles before applying

### DIFF
--- a/src/integration/smart-charging/SmartChargingIntegration.ts
+++ b/src/integration/smart-charging/SmartChargingIntegration.ts
@@ -43,6 +43,9 @@ export default abstract class SmartChargingIntegration<T extends SmartChargingSe
       });
       return;
     }
+    // Sort charging profiles
+    // Lower limits need to be set first. (When high limit is set first, it may appear that the corresponding low limit is not set yet)
+    chargingProfiles.sort((a, b) => a.profile.chargingSchedule.chargingSchedulePeriod[0].limit - b.profile.chargingSchedule.chargingSchedulePeriod[0].limit);
     // Apply the charging plans
     for (const chargingProfile of chargingProfiles) {
       try {


### PR DESCRIPTION
The reason for sorting the profiles is, that we need to ensure to first limit the stations with the lower limits, before we set the other ones free with higher limits. (Otherwise there are transition periods with two high limits, which could exceed the overall limit)

![image](https://user-images.githubusercontent.com/33114317/122229651-3b0e5a00-ceb9-11eb-85f1-1955bbbfad35.png)
