### PR TITLE
HOTFIX - async task manager - running same task several times!!!

### DIFF
--- a/src/async-task/AsyncTaskManager.ts
+++ b/src/async-task/AsyncTaskManager.ts
@@ -64,7 +64,6 @@ export default class AsyncTaskManager {
       const asyncTasks = await AsyncTaskStorage.getAsyncTasks(
         { status: AsyncTaskStatus.PENDING }, Constants.DB_PARAMS_MAX_LIMIT);
       // Process them
-      let abstractAsyncTask: AbstractAsyncTask;
       if (!Utils.isEmptyArray(asyncTasks.result)) {
         await Logging.logInfo({
           tenantID: Constants.DEFAULT_TENANT,
@@ -75,6 +74,7 @@ export default class AsyncTaskManager {
         await Promise.map(asyncTasks.result,
           async (asyncTask: AsyncTask) => {
             // Tasks
+            let abstractAsyncTask: AbstractAsyncTask;
             switch (asyncTask.name) {
               case AsyncTasks.BILL_TRANSACTION:
                 abstractAsyncTask = new BillTransactionAsyncTask(asyncTask);


### PR DESCRIPTION
Very tricky issue due to Promise.map!

When **n** async tasks were in a PENDING state. The async task manager was running **n** times the lastest one!
This leading to an exception when the task tries to acquire an exclusive lock.


