### PR TITLE
tenant creation endpoint - schema validation accepting the ID

### DIFF
--- a/src/assets/server/rest/v1/schemas/tenant/tenant-create.json
+++ b/src/assets/server/rest/v1/schemas/tenant/tenant-create.json
@@ -2,6 +2,9 @@
   "title": "Create one Tenant",
   "type": "object",
   "properties": {
+    "id": {
+      "$ref": "common.json#/definitions/id"
+    },
     "name": {
       "$ref": "tenant.json#/definitions/name"
     },


### PR DESCRIPTION
tenant created by the unit tests had a different id than the expected one.

This was due to the validator of the create tenant endpoint.