### PR TITLE
rest endpoint - url - encode params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16700,24 +16700,6 @@
         }
       }
     },
-    "safe-url-assembler": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/safe-url-assembler/-/safe-url-assembler-1.3.5.tgz",
-      "integrity": "sha1-vINxZ2wR7KcikQ/XRzIzsIvXwXs=",
-      "dev": true,
-      "requires": {
-        "extend": "~3.0.0",
-        "qs": "~6.3.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        }
-      }
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -243,7 +243,6 @@
     "querystring": "^0.2.1",
     "rimraf": "^3.0.2",
     "rosie": "^2.1.0",
-    "safe-url-assembler": "^1.3.5",
     "ts-loader": "^8.3.0",
     "ts-node": "^10.0.0",
     "ts-node-dev": "^1.1.6",

--- a/test/api/client/utils/CrudApi.ts
+++ b/test/api/client/utils/CrudApi.ts
@@ -1,5 +1,4 @@
 import AuthenticatedBaseApi from './AuthenticatedBaseApi';
-import SafeUrlAssembler from 'safe-url-assembler';
 import { ServerRoute } from '../../../../src/types/Server';
 import TestConstants from './TestConstants';
 
@@ -135,14 +134,14 @@ export default class CrudApi {
   }
 
   // Build URL targeting REST endpoints
-  protected buildRestEndpointUrl(urlPatternAsString: ServerRoute, params: {
-    // Just a flat list of key/value pairs!
-    [name: string]: string | number | null;
-  } = {}): string {
-    const url = SafeUrlAssembler('/v1/api/')
-      .template(urlPatternAsString)
-      .param(params);
-    return url.toString();
+  protected buildRestEndpointUrl(urlPatternAsString: ServerRoute, params: { [name: string]: string | number | null } = {}): string {
+    let resolvedUrlPattern = urlPatternAsString as string;
+    for (const key in params) {
+      if (Object.prototype.hasOwnProperty.call(params, key)) {
+        resolvedUrlPattern = resolvedUrlPattern.replace(`:${key}`, encodeURIComponent(params[key]));
+      }
+    }
+    return resolvedUrlPattern;
   }
 
   // Build the paging in the Queryparam

--- a/test/api/client/utils/CrudApi.ts
+++ b/test/api/client/utils/CrudApi.ts
@@ -134,14 +134,24 @@ export default class CrudApi {
   }
 
   // Build URL targeting REST endpoints
+  // protected buildRestEndpointUrl(urlPatternAsString: ServerRoute, params: { [name: string]: string | number | null } = {}): string {
+  //   let resolvedUrlPattern = urlPatternAsString as string;
+  //   for (const key in params) {
+  //     if (Object.prototype.hasOwnProperty.call(params, key)) {
+  //       resolvedUrlPattern = resolvedUrlPattern.replace(`:${key}`, encodeURIComponent(params[key]));
+  //     }
+  //   }
+  //   return resolvedUrlPattern;
+  // }
+
   protected buildRestEndpointUrl(urlPatternAsString: ServerRoute, params: { [name: string]: string | number | null } = {}): string {
     let resolvedUrlPattern = urlPatternAsString as string;
     for (const key in params) {
       if (Object.prototype.hasOwnProperty.call(params, key)) {
-        resolvedUrlPattern = resolvedUrlPattern.replace(`:${key}`, encodeURIComponent(params[key]));
+        resolvedUrlPattern = resolvedUrlPattern.replace(`:${key}`, params[key] as string);
       }
     }
-    return resolvedUrlPattern;
+    return '/v1/api/' + resolvedUrlPattern;
   }
 
   // Build the paging in the Queryparam

--- a/test/api/client/utils/CrudApi.ts
+++ b/test/api/client/utils/CrudApi.ts
@@ -134,21 +134,11 @@ export default class CrudApi {
   }
 
   // Build URL targeting REST endpoints
-  // protected buildRestEndpointUrl(urlPatternAsString: ServerRoute, params: { [name: string]: string | number | null } = {}): string {
-  //   let resolvedUrlPattern = urlPatternAsString as string;
-  //   for (const key in params) {
-  //     if (Object.prototype.hasOwnProperty.call(params, key)) {
-  //       resolvedUrlPattern = resolvedUrlPattern.replace(`:${key}`, encodeURIComponent(params[key]));
-  //     }
-  //   }
-  //   return resolvedUrlPattern;
-  // }
-
   protected buildRestEndpointUrl(urlPatternAsString: ServerRoute, params: { [name: string]: string | number | null } = {}): string {
     let resolvedUrlPattern = urlPatternAsString as string;
     for (const key in params) {
       if (Object.prototype.hasOwnProperty.call(params, key)) {
-        resolvedUrlPattern = resolvedUrlPattern.replace(`:${key}`, params[key] as string);
+        resolvedUrlPattern = resolvedUrlPattern.replace(`:${key}`, encodeURIComponent(params[key]));
       }
     }
     return '/v1/api/' + resolvedUrlPattern;


### PR DESCRIPTION
Removed dependency to safe-url-assembler

- The URL generation used to test REST endpoints has been adapted
- URL path is properly encoded using **encodeUriComponent** method. 