### PR TITLE
Display footer stats for current charging sessions

### DIFF
--- a/src/assets/server/rest/v1/schemas/transaction/transactions-get.json
+++ b/src/assets/server/rest/v1/schemas/transaction/transactions-get.json
@@ -55,7 +55,7 @@
     "Statistics": {
       "type": "string",
       "sanitize": "mongo",
-      "enum": ["refund", "history"]
+      "enum": ["refund", "history", "ongoing"]
     },
     "ReportIDs": {
       "$ref": "common.json#/definitions/ids"

--- a/src/types/requests/HttpTransactionRequest.ts
+++ b/src/types/requests/HttpTransactionRequest.ts
@@ -37,7 +37,7 @@ export interface HttpTransactionsRequest extends HttpDatabaseRequest {
   RefundStatus?: string;
   InactivityStatus?: InactivityStatus;
   MinimalPrice?: boolean;
-  Statistics?: 'refund' | 'history';
+  Statistics?: 'refund' | 'history' | 'ongoing';
   ReportIDs?: string;
   Status?: 'completed' | 'active';
 }


### PR DESCRIPTION
Backend changes required to display summary statistics. If the status of request is "Statistics": "ongoing", create a summary similar to "Statistics": "history" but with different parameters from the DB.