### PR TITLE
Billing - take into account transaction timezone

### DIFF
--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -1180,9 +1180,9 @@ export default class StripeBillingIntegration extends BillingIntegration {
     const chargeBox = transaction.chargeBox;
     const i18nManager = I18nManager.getInstanceForLocale(transaction.user.locale);
     const sessionID = String(transaction?.id);
-    const startDate = i18nManager.formatDateTime(transaction.timestamp, 'LL');
-    const startTime = i18nManager.formatDateTime(transaction.timestamp, 'LT');
-    const stopTime = i18nManager.formatDateTime(transaction.stop.timestamp, 'LT');
+    const startDate = i18nManager.formatDateTime(transaction.timestamp, 'LL', transaction.timezone);
+    const startTime = i18nManager.formatDateTime(transaction.timestamp, 'LT', transaction.timezone);
+    const stopTime = i18nManager.formatDateTime(transaction.stop.timestamp, 'LT', transaction.timezone);
     const formattedConsumptionkWh = this.formatConsumptionToKWh(transaction);
     const timeSpent = this.convertTimeSpentToString(transaction);
     // TODO: Determine the description pattern to use according to the billing settings

--- a/src/utils/I18nManager.ts
+++ b/src/utils/I18nManager.ts
@@ -74,8 +74,11 @@ export default class I18nManager {
     return '0';
   }
 
-  public formatDateTime(value: Date, format = 'LLL'): string {
+  public formatDateTime(value: Date, format = 'LLL', timezone: string = null): string {
     moment.locale(this.language);
+    if (timezone) {
+      return moment(new Date(value)).tz(timezone).format(format);
+    }
     return moment(new Date(value)).format(format);
   }
 }


### PR DESCRIPTION
Start time shown on each invoice item was not taking into account the transaction timezone.
This has been fixed!