### PR TITLE
billing - asyncTask changed to prevent invoicing conflicts

### DIFF
--- a/src/integration/billing/stripe/StripeBillingIntegration.ts
+++ b/src/integration/billing/stripe/StripeBillingIntegration.ts
@@ -966,6 +966,7 @@ export default class StripeBillingIntegration extends BillingIntegration {
       tenantID: this.tenant.id,
       parameters: {
         transactionID: String(transaction.id),
+        userID: transaction.userID
       },
       module: MODULE_NAME,
       method: 'stopTransaction',

--- a/test/config.js
+++ b/test/config.js
@@ -247,10 +247,10 @@ const config = convict({
       format: Number,
       default: 20
     },
-    replicateSet: {
-      doc: 'replicateSet',
+    replicaSet: {
+      doc: 'replica set name',
       format: String,
-      default: ''
+      default: 'rs0'
     },
     monitorDBChange: {
       doc: 'monitor changes',

--- a/test/config.js
+++ b/test/config.js
@@ -247,6 +247,11 @@ const config = convict({
       format: Number,
       default: 20
     },
+    replicateSet: {
+      doc: 'replicateSet',
+      format: String,
+      default: ''
+    },
     monitorDBChange: {
       doc: 'monitor changes',
       format: Boolean,


### PR DESCRIPTION
Potential conflicts have been detected when two async billing tasks for the same user are running in parallel and generating stripe invoice items.

The side effect, is that the first invoice was containing 2 invoice items while the second one was failing because no pending invoice items were available (i.e.: nothing to bill).

The solution here relies on the acquireExclusiveLock() on the user, with a time out to make sure the 2nd invoice waits for the first one to complete.

