### PR TITLE
Fix computation of evse_uid and evse_uid when a charging station contains several charge points with the flag cannotChargeInParallel set to true

### DIFF
--- a/src/client/ocpi/CpoOCPIClient.ts
+++ b/src/client/ocpi/CpoOCPIClient.ts
@@ -1003,12 +1003,12 @@ export default class CpoOCPIClient extends OCPIClient {
       connectorId: number, countryId: string, partyId: string): OCPILocation {
     const connectors: OCPIConnector[] = [];
     let status: ChargePointStatus;
-    for (const chargingStationConnector of chargingStation.connectors) {
-      if (chargingStationConnector.connectorId === connectorId) {
-        connectors.push(OCPIUtilsService.convertConnector2OCPIConnector(tenant, chargingStation, chargingStationConnector, countryId, partyId));
-        status = chargingStationConnector.status;
-        break;
-      }
+    const connector = Utils.getConnectorFromID(chargingStation, connectorId);
+    let chargePoint;
+    if (connector) {
+      connectors.push(OCPIUtilsService.convertConnector2OCPIConnector(tenant, chargingStation, connector, countryId, partyId));
+      status = connector.status;
+      chargePoint = Utils.getChargePointFromID(chargingStation, connector.chargePointID);
     }
     const ocpiLocation: OCPILocation = {
       id: site.id,
@@ -1024,8 +1024,7 @@ export default class CpoOCPIClient extends OCPIClient {
       type: OCPILocationType.UNKNOWN,
       evses: [{
         uid: OCPIUtils.buildEvseUID(chargingStation, Utils.getConnectorFromID(chargingStation, connectorId)),
-        evse_id: RoamingUtils.buildEvseID(countryId, partyId, chargingStation.id,
-          Utils.getConnectorFromID(chargingStation, connectorId).connectorId),
+        evse_id: RoamingUtils.buildEvseID(countryId, partyId, chargingStation.id, chargePoint && chargePoint.cannotChargeInParallel ? chargePoint.chargePointID : connectorId),
         location_id: chargingStation.siteID,
         status: OCPIUtilsService.convertStatus2OCPIStatus(status),
         capabilities: [OCPICapability.REMOTE_START_STOP_CAPABLE, OCPICapability.RFID_READER],

--- a/src/server/ocpi/OCPIUtils.ts
+++ b/src/server/ocpi/OCPIUtils.ts
@@ -79,6 +79,13 @@ export default class OCPIUtils {
   }
 
   public static buildEvseUID(chargingStation: ChargingStation, connector: Connector): string {
+    // connectors are grouped in the same evse when the connectors cannot charge in parallel
+    if (connector.chargePointID) {
+      const chargePoint = Utils.getChargePointFromID(chargingStation, connector.chargePointID);
+      if (chargePoint && chargePoint.cannotChargeInParallel) {
+        return `${chargingStation.id}*${connector.connectorId}`;
+      }
+    }
     return `${chargingStation.id}*${connector.connectorId}`;
   }
 

--- a/src/server/ocpi/OCPIUtils.ts
+++ b/src/server/ocpi/OCPIUtils.ts
@@ -83,7 +83,7 @@ export default class OCPIUtils {
     if (connector.chargePointID) {
       const chargePoint = Utils.getChargePointFromID(chargingStation, connector.chargePointID);
       if (chargePoint && chargePoint.cannotChargeInParallel) {
-        return `${chargingStation.id}*${connector.connectorId}`;
+        return `${chargingStation.id}*${chargePoint.chargePointID}`;
       }
     }
     return `${chargingStation.id}*${connector.connectorId}`;

--- a/src/server/ocpi/ocpi-services-impl/ocpi-2.1.1/OCPIUtilsService.ts
+++ b/src/server/ocpi/ocpi-services-impl/ocpi-2.1.1/OCPIUtilsService.ts
@@ -853,9 +853,9 @@ export default class OCPIUtilsService {
     const connectorOneStatus = OCPIUtilsService.convertToOneConnectorStatus(connectors);
     // Build evse
     const evse: OCPIEvse = {
-      // Force the connector id to always be 1 on charging station that have mutually exclusive connectors
-      uid: OCPIUtils.buildEvseUID(chargingStation, { connectorId: 1 } as Connector),
-      evse_id: RoamingUtils.buildEvseID(options.countryID, options.partyID, chargingStation.id, 1),
+      // Evse uid must contains the chargePoint.id
+      uid: OCPIUtils.buildEvseUID(chargingStation, connectors[0]),
+      evse_id: RoamingUtils.buildEvseID(options.countryID, options.partyID, chargingStation.id, chargePoint.chargePointID),
       location_id: chargingStation.siteID,
       status: chargingStation.inactive ? OCPIEvseStatus.INOPERATIVE : OCPIUtilsService.convertStatus2OCPIStatus(connectorOneStatus),
       capabilities: [OCPICapability.REMOTE_START_STOP_CAPABLE, OCPICapability.RFID_READER],


### PR DESCRIPTION
Fix computation of evse_uid and evse_uid when a charging station contains several charge points with the flag cannotChargeInParallel set to true