### PR TITLE
WIP : Invoices modal back

### DIFF
--- a/src/authorization/Authorizations.ts
+++ b/src/authorization/Authorizations.ts
@@ -662,6 +662,18 @@ export default class Authorizations {
       { user: userID, owner: loggedUser.id });
   }
 
+  public static async canPayInvoice(loggedUser: UserToken, userID: string): Promise<boolean> {
+    return Authorizations.canPerformAction(loggedUser, Entity.INVOICE, Action.PAY_BILLING_INVOICE,
+      { user: userID, owner: loggedUser.id });
+  }
+
+  // TODO: change authorization !!!
+  // DOES NOT WORK as even with creating the paymentintent it does not allow to .pay() when 3DS verification needed
+  public static async canCreatePaymentIntent(loggedUser: UserToken, userID: string): Promise<boolean> {
+    return Authorizations.canPerformAction(loggedUser, Entity.INVOICE, Action.PAY_BILLING_INVOICE,
+      { user: userID, owner: loggedUser.id });
+  }
+
   public static async canCheckAssetConnection(loggedUser: UserToken): Promise<boolean> {
     return Authorizations.canPerformAction(loggedUser, Entity.ASSET, Action.CHECK_CONNECTION);
   }

--- a/src/authorization/AuthorizationsDefinition.ts
+++ b/src/authorization/AuthorizationsDefinition.ts
@@ -218,7 +218,7 @@ const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
       // { resource: Entity.INVOICES, action: [Action.LIST, Action.SYNCHRONIZE] },
       // { resource: Entity.INVOICE, action: [Action.DOWNLOAD, Action.CREATE] },
       { resource: Entity.INVOICES, action: [Action.LIST] },
-      { resource: Entity.INVOICE, action: [Action.DOWNLOAD, Action.READ] },
+      { resource: Entity.INVOICE, action: [Action.DOWNLOAD, Action.READ, Action.PAY_BILLING_INVOICE] },
       {
         resource: Entity.ASSET, action: [Action.CREATE, Action.READ, Action.UPDATE, Action.DELETE,
           Action.CHECK_CONNECTION, Action.RETRIEVE_CONSUMPTION, Action.CREATE_CONSUMPTION]

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -14,6 +14,7 @@ import NotificationHandler from '../../notification/NotificationHandler';
 import { Request } from 'express';
 import { ServerAction } from '../../types/Server';
 import SettingStorage from '../../storage/mongodb/SettingStorage';
+import { Stripe } from 'stripe';
 import Tenant from '../../types/Tenant';
 import TenantStorage from '../../storage/mongodb/TenantStorage';
 import TransactionStorage from '../../storage/mongodb/TransactionStorage';
@@ -621,13 +622,21 @@ export default abstract class BillingIntegration {
 
   abstract downloadInvoiceDocument(invoice: BillingInvoice): Promise<Buffer>;
 
-  abstract chargeInvoice(invoice: BillingInvoice): Promise<BillingInvoice>;
+  // Modifications working for one time payment as long as we don't need 3DS verification
+  abstract chargeInvoice(invoice: BillingInvoice, parameter?: Stripe.InvoicePayParams): Promise<BillingInvoice>;
 
   abstract consumeBillingEvent(req: Request): Promise<boolean>;
 
-  abstract setupPaymentMethod(user: User, paymentMethodId: string): Promise<BillingOperationResult>;
+  // Modifications working for one time payment as long as we don't need 3DS verification
+  abstract setupPaymentMethod(user: User, paymentMethodId: string, oneTimePayment?: boolean): Promise<BillingOperationResult>;
 
   abstract getPaymentMethods(user: User): Promise<BillingPaymentMethod[]>;
+
+  // BELOW USELESS FOR NOW
+  abstract setupPaymentIntent(user: User, invoice: BillingInvoice, paymentMethodID: string): Promise<BillingOperationResult>;
+
+  // BELOW USELESS FOR NOW
+  abstract updateInvoice(paymentIntent: any): void;
 
   abstract deletePaymentMethod(user: User, paymentMethodId: string): Promise<BillingOperationResult>;
 

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -636,7 +636,7 @@ export default abstract class BillingIntegration {
   abstract setupPaymentIntent(user: User, invoice: BillingInvoice, paymentMethodID: string): Promise<BillingOperationResult>;
 
   // BELOW USELESS FOR NOW
-  abstract updateInvoice(paymentIntent: any): void;
+  // abstract updateInvoice(paymentIntent: any): void;
 
   abstract deletePaymentMethod(user: User, paymentMethodId: string): Promise<BillingOperationResult>;
 

--- a/src/server/rest/v1/router/api/BillingRouter.ts
+++ b/src/server/rest/v1/router/api/BillingRouter.ts
@@ -36,6 +36,9 @@ export default class BillingRouter {
     this.buildRouteBillingInvoices();
     this.buildRouteBillingInvoice();
     this.buildRouteBillingInvoiceDownload();
+    this.buildRouteBillingInvoicePayment();
+    this.buildRouteBillingPaymentIntentSetup();
+    // this.buildRouteBillingSetupInvoicePayment();
     return this.router;
   }
 
@@ -85,6 +88,26 @@ export default class BillingRouter {
       // STRIPE prerequisite - ask for a setup intent first!
       req.body.userID = req.params.userID;
       void RouterUtils.handleServerAction(BillingService.handleBillingSetupPaymentMethod.bind(this), ServerAction.BILLING_SETUP_PAYMENT_METHOD, req, res, next);
+    });
+  }
+
+  // Modifications working for one time payment as long as we don't need 3DS verification
+  protected buildRouteBillingInvoicePayment(): void {
+    this.router.post(`/${ServerRoute.REST_BILLING_INVOICE_PAYMENT}`, (req: Request, res: Response, next: NextFunction) => {
+      // STRIPE prerequisite - ask for a payment intent first!
+      req.body.userID = req.params.userID;
+      req.body.invoiceId = req.params.invoiceID;
+      req.body.paymentMethodId = req.params.paymentMethodID;
+      void RouterUtils.handleServerAction(BillingService.handleBillingInvoicePayment.bind(this), ServerAction.BILLING_INVOICE_PAYMENT, req, res, next);
+    });
+  }
+
+  // BELOW USELESS as we cannot .pay() with paymentintent
+  protected buildRouteBillingPaymentIntentSetup(): void {
+    this.router.post(`/${ServerRoute.REST_BILLING_PAYMENT_INTENT_SETUP}`, (req: Request, res: Response, next: NextFunction) => {
+      // STRIPE prerequisite - ask for a payment intent first!
+      req.body.userID = req.params.userID;
+      void RouterUtils.handleServerAction(BillingService.handleBillingSetupPaymentIntent.bind(this), ServerAction.BILLING_INVOICE_PAYMENT, req, res, next);
     });
   }
 

--- a/src/server/rest/v1/service/security/BillingSecurity.ts
+++ b/src/server/rest/v1/service/security/BillingSecurity.ts
@@ -1,4 +1,4 @@
-import { HttpBillingInvoiceRequest, HttpBillingRequest, HttpBillingWebHookRequest, HttpDeletePaymentMethod, HttpPaymentMethods, HttpSetupPaymentMethod } from '../../../../../types/requests/HttpBillingRequest';
+import { HttpBillingInvoiceRequest, HttpBillingRequest, HttpBillingWebHookRequest, HttpDeletePaymentMethod, HttpPaymentMethods, HttpSetupPaymentIntent, HttpSetupPaymentMethod } from '../../../../../types/requests/HttpBillingRequest';
 import { HttpCreateTransactionInvoiceRequest, HttpForceSynchronizeUserInvoicesRequest, HttpSynchronizeUserRequest } from '../../../../../types/requests/HttpUserRequest';
 
 import Utils from '../../../../../utils/Utils';
@@ -88,6 +88,15 @@ export default class BillingSecurity {
     return {
       userID: sanitize(requestBody.userID),
       paymentMethodId: sanitize(requestBody.paymentMethodId),
+    };
+  }
+
+  // TODO: to be verified depending on what we decide to use
+  static filterInvoicePaymentRequest(requestQuery: any): HttpSetupPaymentIntent {
+    return {
+      userID: sanitize(requestQuery.userID),
+      invoiceID: sanitize(requestQuery.invoiceID),
+      paymentMethodID: sanitize(requestQuery.paymentMethodID)
     };
   }
 }

--- a/src/types/Authorization.ts
+++ b/src/types/Authorization.ts
@@ -139,6 +139,10 @@ export enum Action {
   BILLING_SETUP_PAYMENT_METHOD = 'BillingSetupPaymentMethod',
   BILLING_PAYMENT_METHODS = 'BillingPaymentMethods',
   BILLING_DELETE_PAYMENT_METHOD = 'BillingDeletePaymentMethod',
+  // TODO: to be verified depending on what we decide to use
+  BILLING_SETUP_PAYMENT_INTENT = 'BillingSetupPaymentIntent',
+  BILLING_INVOICE_PAYMENT = 'BillingInvoicePayment',
+  PAY_BILLING_INVOICE = 'PayBillingInvoice',
   BILLING_CHARGE_INVOICE = 'BillingChargeInvoice',
   CHECK_CONNECTION = 'CheckConnection',
   CLEAR_BILLING_TEST_DATA = 'ClearBillingTestData',

--- a/src/types/Server.ts
+++ b/src/types/Server.ts
@@ -423,6 +423,8 @@ export enum ServerAction {
   BILLING_DOWNLOAD_INVOICE = 'BillingDownloadInvoice',
   BILLING_NEW_INVOICE = 'BillingNewInvoice',
   BILLING_SETUP_PAYMENT_METHOD = 'BillingSetupPaymentMethod',
+  BILLING_SETUP_PAYMENT_INTENT = 'BillingSetupPaymentIntent',
+  BILLING_INVOICE_PAYMENT = 'BillingInvoicePayment',
   BILLING_PAYMENT_METHODS = 'BillingPaymentMethods',
   BILLING_DELETE_PAYMENT_METHOD = 'BillingDeletePaymentMethod',
   BILLING_CHARGE_INVOICE = 'BillingChargeInvoice',
@@ -526,6 +528,9 @@ export enum ServerRoute {
   // BILLING URLs for CRUD operations on PAYMENT METHODS
   REST_BILLING_PAYMENT_METHODS = 'users/:userID/payment-methods',
   REST_BILLING_PAYMENT_METHOD = 'users/:userID/payment-methods/:paymentMethodID',
+  // TODO: to be verified depending on what we decide to use
+  REST_BILLING_INVOICE_PAYMENT = 'users/:userID/pay/:invoiceID/:paymentMethodID',
+  REST_BILLING_PAYMENT_INTENT_SETUP = 'users/:userID/paymentIntent/:invoiceID',
 
   // BILLING URLs for Non-CRUD Operations on PAYMENT METHODS
   REST_BILLING_PAYMENT_METHOD_SETUP = 'users/:userID/payment-methods/setup',

--- a/src/types/requests/HttpBillingRequest.ts
+++ b/src/types/requests/HttpBillingRequest.ts
@@ -24,6 +24,13 @@ export interface HttpSetupPaymentMethod {
   paymentMethodId?: string;
 }
 
+// TODO: to be verified depending on what we decide to use
+export interface HttpSetupPaymentIntent {
+  userID: string;
+  invoiceID: string;
+  paymentMethodID?: string;
+}
+
 export interface HttpPaymentMethods {
   userID: string;
 }


### PR DESCRIPTION
I let comments on what I tried so far

Need to ask stripe the best way to achieve what we want to do :
use the .pay() when doing a one time payment so the payment is attached to the invoice

- today it sounds like it works with normal card number NOT with 3DS card !! // please retry normal card payment
- didn't find a way to attach payment even with payment intent (.pay() wait for a payment_method ID OR a source)
- when doing a stripe payment directly, looking at the logs it looks like they use 'source' stuff but they also say it's deprecated in the doc...