### PR TITLE
Fixed logging service

### DIFF
--- a/src/server/rest/v1/service/LoggingService.ts
+++ b/src/server/rest/v1/service/LoggingService.ts
@@ -125,7 +125,7 @@ export default class LoggingService {
       }
     }
     // Get logs
-    const loggings = await LoggingStorage.getLogs(req.user.tenantID, {
+    const loggings = await LoggingStorage.getLogs(req.tenant, {
       search: filteredRequest.Search,
       startDateTime: filteredRequest.StartDateTime,
       endDateTime: filteredRequest.EndDateTime,


### PR DESCRIPTION
Logging service still used the tenant id instead of tenant object
Maybe the check tenant method needs to be extended to check the validity of a tenant object