### PR TITLE
Adding changes to handle missing charging station in charging profile.

### DIFF
--- a/src/integration/smart-charging/sap-smart-charging/SapSmartChargingIntegration.ts
+++ b/src/integration/smart-charging/sap-smart-charging/SapSmartChargingIntegration.ts
@@ -687,6 +687,7 @@ export default class SapSmartChargingIntegration extends SmartChargingIntegratio
       // Build charging profile with charging station id and connector id
       const chargingProfile: ChargingProfile = {
         chargingStationID: chargingStationID,
+        chargingStation: chargingStation,
         connectorID: connectorID,
         chargePointID: chargePoint.chargePointID,
         profile: profile
@@ -787,7 +788,7 @@ export default class SapSmartChargingIntegration extends SmartChargingIntegratio
             const fluctuation = (asset.staticValueWatt * (asset.fluctuationPercent / 100));
             let consumptionSaveValue = 0;
             // Check if current consumption is up to date
-            if ((moment().diff(moment(asset.lastConsumption.timestamp), 'minutes')) < 2) {
+            if ((moment().diff(moment(asset.lastConsumption?.timestamp), 'minutes')) < 2) {
               if (asset.currentInstantWatts > 0) {
                 // Ensure consumption does not exceed static value
                 consumptionSaveValue = ((asset.currentInstantWatts + fluctuation < asset.staticValueWatt) ? (asset.currentInstantWatts + fluctuation) : asset.staticValueWatt);


### PR DESCRIPTION
Charging station under charging profile was set to undefined, as a result of which exceptions were being thrown when siteID, siteAreaID or companyID from chargingStation was being accessed. 