### PR TITLE
pricing - consider transaction timezone 

### DIFF
--- a/src/integration/pricing/ConsumptionPricer.ts
+++ b/src/integration/pricing/ConsumptionPricer.ts
@@ -63,19 +63,20 @@ export default class ConsumptionPricer {
     return true;
   }
 
-
   private checkTimeValidity(restrictions: PricingRestriction): boolean {
+    // The time range restriction must consider the charging station timezone
+    const timezone = this.pricingModel.pricerContext.timezone;
     if (!Utils.isNullOrUndefined(restrictions.timeFrom)) {
-      const hours = Utils.convertToInt(restrictions.timeFrom.slice(0, 2));
-      const minutes = Utils.convertToInt(restrictions.timeFrom.slice(3));
-      if (moment(this.consumptionData.startedAt).isBefore(new Date().setHours(hours, minutes))) {
+      const hour = Utils.convertToInt(restrictions.timeFrom.slice(0, 2));
+      const minute = Utils.convertToInt(restrictions.timeFrom.slice(3));
+      if (moment(this.consumptionData.startedAt).tz(timezone).isBefore(moment().tz(timezone).set({ hour, minute }))) {
         return false;
       }
     }
     if (!Utils.isNullOrUndefined(restrictions.timeTo)) {
-      const hours = Utils.convertToInt(restrictions.timeTo.slice(0, 2));
-      const minutes = Utils.convertToInt(restrictions.timeTo.slice(3));
-      if (moment(this.consumptionData.startedAt).isSameOrAfter(new Date().setHours(hours, minutes))) {
+      const hour = Utils.convertToInt(restrictions.timeTo.slice(0, 2));
+      const minute = Utils.convertToInt(restrictions.timeTo.slice(3));
+      if (moment(this.consumptionData.startedAt).tz(timezone).isSameOrAfter(moment().tz(timezone).set({ hour, minute }))) {
         return false;
       }
     }

--- a/src/integration/pricing/PricingEngine.ts
+++ b/src/integration/pricing/PricingEngine.ts
@@ -36,7 +36,8 @@ export default class PricingEngine {
     const resolvedPricingModel: ResolvedPricingModel = {
       pricerContext: {
         flatFeeAlreadyPriced: false,
-        sessionStartDate: transaction.timestamp
+        sessionStartDate: transaction.timestamp,
+        timezone: transaction.timezone
       },
       pricingDefinitions
     };

--- a/src/types/Pricing.ts
+++ b/src/types/Pricing.ts
@@ -31,6 +31,7 @@ export interface ConsumptionPricerContext {
   lastAbsorbedConsumption?: number, // IMPORTANT - used to price E when stepSize is set!
   lastAbsorbedChargingTime?: Date // IMPORTANT - used to price CT when stepSize is set!
   lastAbsorbedParkingTime?: Date, // IMPORTANT - used to price PT when stepSize is set!
+  timezone: string; // IMPORTANT - time range restrictions must consider the charging station location (and its time zone)
 }
 
 interface PricingDefinitionInternal {

--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -19,6 +19,7 @@ import { UserInErrorType } from '../../src/types/InError';
 import chaiSubset from 'chai-subset';
 import config from '../config';
 import global from '../../src/types/GlobalType';
+import moment from 'moment';
 import responseHelper from '../helpers/responseHelper';
 
 chai.use(chaiSubset);
@@ -787,8 +788,10 @@ describe('Billing', function() {
         });
 
         it('should bill an invoice taking the Time into account', async () => {
-          await billingTestHelper.initChargingStationContext2TestFastCharger('NEXT_HOUR');
-          await billingTestHelper.initChargingStationContext2TestFastCharger('THIS_HOUR');
+          const atThatParticularMoment = moment();
+          await billingTestHelper.initChargingStationContext2TestTimeRestrictions('OTHER_HOURS', atThatParticularMoment);
+          await billingTestHelper.initChargingStationContext2TestTimeRestrictions('NEXT_HOUR', atThatParticularMoment);
+          await billingTestHelper.initChargingStationContext2TestTimeRestrictions('FOR_HALF_AN_HOUR', atThatParticularMoment);
           // A tariff applied immediately
           await billingTestHelper.userService.billingApi.forceSynchronizeUser({ id: billingTestHelper.userContext.id });
           const userWithBillingData = await billingTestHelper.billingImpl.getUser(billingTestHelper.userContext);


### PR DESCRIPTION
Some changes to make sure the location of the charging station is taken into account when checking "time range" restrictions while pricing the charging session consumption.


