### PR TITLE
pricing - warning when timezone is unknown

### DIFF
--- a/src/integration/pricing/ConsumptionPricer.ts
+++ b/src/integration/pricing/ConsumptionPricer.ts
@@ -66,6 +66,10 @@ export default class ConsumptionPricer {
   private checkTimeValidity(restrictions: PricingRestriction): boolean {
     // The time range restriction must consider the charging station timezone
     const timezone = this.pricingModel.pricerContext.timezone;
+    if (!timezone) {
+      // Charging station timezone is not known - time restrictions cannot be used in such context
+      return false;
+    }
     if (!Utils.isNullOrUndefined(restrictions.timeFrom)) {
       const hour = Utils.convertToInt(restrictions.timeFrom.slice(0, 2));
       const minute = Utils.convertToInt(restrictions.timeFrom.slice(3));

--- a/src/integration/pricing/PricingEngine.ts
+++ b/src/integration/pricing/PricingEngine.ts
@@ -32,6 +32,16 @@ export default class PricingEngine {
       pricingDefinitions.push(...await PricingEngine.getPricingDefinitions4Entity(tenant, transaction, chargingStation, PricingEntity.COMPANY, transaction.companyID.toString()));
       pricingDefinitions.push(...await PricingEngine.getPricingDefinitions4Entity(tenant, transaction, chargingStation, PricingEntity.TENANT, tenant.id));
     }
+    if (!transaction.timezone) {
+      await Logging.logWarning({
+        tenantID: tenant.id,
+        module: MODULE_NAME,
+        action: ServerAction.PRICING,
+        method: 'resolvePricingContext',
+        message: 'Unexpected situation: The timezone of the transaction is unknown. Make sure the location of the charging station is properly set!',
+        ...LoggingHelper.getTransactionProperties(transaction)
+      });
+    }
     // Return the resolution result as a resolved pricing model
     const resolvedPricingModel: ResolvedPricingModel = {
       pricerContext: {


### PR DESCRIPTION
consumption pricer now properly handles transactions where the timezone is not set