### PR TITLE
pricing - daysOfTheWeek - take timezone into account

### DIFF
--- a/src/integration/pricing/ConsumptionPricer.ts
+++ b/src/integration/pricing/ConsumptionPricer.ts
@@ -56,8 +56,13 @@ export default class ConsumptionPricer {
 
   private checkDayOfWeek(restrictions: PricingRestriction): boolean {
     if (!Utils.isNullOrUndefined(restrictions.daysOfWeek)) {
+      const timezone = this.pricingModel.pricerContext.timezone;
+      if (!timezone) {
+        // Charging station timezone is not known - 'days of the week' restrictions cannot be used in such context
+        return false;
+      }
       // ACHTUNG - moment.isoWeekday() - 1:MONDAY, 7: SUNDAY
-      return restrictions.daysOfWeek.includes(moment(this.consumptionData.startedAt).isoWeekday());
+      return restrictions.daysOfWeek.includes(moment(this.consumptionData.startedAt).tz(timezone).isoWeekday());
     }
     // No restrictions related to the day of the week
     return true;

--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -772,11 +772,16 @@ describe('Billing', function() {
           // Check that we have a new invoice with an invoiceID and an invoiceNumber
           await billingTestHelper.checkTransactionBillingData(transactionID, BillingInvoiceStatus.PAID, 17.37);
         });
+      });
 
+      describe('Check Dynamic Restrictions on COMBO CCS - DC', () => {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        before(async () => {
+        });
 
         it('should bill an invoice taking the Day of the week into account', async () => {
-          await billingTestHelper.initChargingStationContext2TestFastCharger('TODAY');
-          await billingTestHelper.initChargingStationContext2TestFastCharger('OTHER_DAYS');
+          await billingTestHelper.initChargingStationContext2TestDaysOfTheWeek('TODAY');
+          await billingTestHelper.initChargingStationContext2TestDaysOfTheWeek('OTHER_DAYS');
           // A tariff applied immediately
           await billingTestHelper.userService.billingApi.forceSynchronizeUser({ id: billingTestHelper.userContext.id });
           const userWithBillingData = await billingTestHelper.billingImpl.getUser(billingTestHelper.userContext);

--- a/test/api/BillingTestHelper.ts
+++ b/test/api/BillingTestHelper.ts
@@ -257,35 +257,6 @@ export default class BillingTestHelper {
           active: true
         }
       };
-    } else if (testMode === 'TODAY') {
-      dimensions = {
-        flatFee: {
-          price: 1.5, // Euro
-          active: true
-        },
-        energy: {
-          price: 1,
-          active: true
-        }
-      };
-      restrictions = {
-        daysOfWeek: [ moment().isoWeekday() ] // Sets today as the only day allowed for this pricing definition
-      };
-    } else if (testMode === 'OTHER_DAYS') {
-      dimensions = {
-        flatFee: {
-          price: 666, // Euro
-          active: true
-        },
-        energy: {
-          price: 666,
-          active: true
-        }
-      };
-      restrictions = {
-        // Sets all other days as the days allowed for this pricing definition
-        daysOfWeek: [ DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY ].filter((day) => day !== moment().isoWeekday())
-      };
     } else {
       dimensions = {
         energy: {
@@ -298,13 +269,57 @@ export default class BillingTestHelper {
     return this.chargingStationContext;
   }
 
-  public async initChargingStationContext2TestTimeRestrictions(testMode = 'E', aParticularMoment: moment.Moment) : Promise<ChargingStationContext> {
-    // Charing Station Context
+  public async initChargingStationContext2TestDaysOfTheWeek(testMode = 'E') : Promise<ChargingStationContext> {
+    // Charging Station Context
     this.siteContext = this.tenantContext.getSiteContext(ContextDefinition.SITE_CONTEXTS.SITE_BASIC);
     this.siteAreaContext = this.siteContext.getSiteAreaContext(ContextDefinition.SITE_AREA_CONTEXTS.WITH_SMART_CHARGING_DC);
     this.chargingStationContext = this.siteAreaContext.getChargingStationContext(ContextDefinition.CHARGING_STATION_CONTEXTS.ASSIGNED_OCPP16 + '-' + ContextDefinition.SITE_CONTEXTS.SITE_BASIC + '-' + ContextDefinition.SITE_AREA_CONTEXTS.WITH_SMART_CHARGING_DC);
     assert(!!this.chargingStationContext, 'Charging station context should not be null');
-    // Make sure to take into account the Charging Station location and its timezone
+    // Take into account the Charging Station location and its timezone
+    const timezone = Utils.getTimezone(this.chargingStationContext.getChargingStation().coordinates);
+    let dimensions: PricingDimensions;
+    let restrictions: PricingRestriction;
+    if (testMode === 'TODAY') {
+      dimensions = {
+        flatFee: {
+          price: 1.5, // Euro
+          active: true
+        },
+        energy: {
+          price: 1,
+          active: true
+        }
+      };
+      restrictions = {
+        daysOfWeek: [ moment().tz(timezone).isoWeekday() ] // Sets today as the only day allowed for this pricing definition
+      };
+    } else { // 'OTHER_DAYS')
+      dimensions = {
+        flatFee: {
+          price: 666, // Euro
+          active: true
+        },
+        energy: {
+          price: 666,
+          active: true
+        }
+      };
+      restrictions = {
+        // Sets all other days as the days allowed for this pricing definition
+        daysOfWeek: [ DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY ].filter((day) => day !== moment().tz(timezone).isoWeekday())
+      };
+    }
+    await this.createTariff4ChargingStation(testMode, this.chargingStationContext.getChargingStation(), dimensions, ConnectorType.COMBO_CCS, restrictions);
+    return this.chargingStationContext;
+  }
+
+  public async initChargingStationContext2TestTimeRestrictions(testMode = 'E', aParticularMoment: moment.Moment) : Promise<ChargingStationContext> {
+    // Charging Station Context
+    this.siteContext = this.tenantContext.getSiteContext(ContextDefinition.SITE_CONTEXTS.SITE_BASIC);
+    this.siteAreaContext = this.siteContext.getSiteAreaContext(ContextDefinition.SITE_AREA_CONTEXTS.WITH_SMART_CHARGING_DC);
+    this.chargingStationContext = this.siteAreaContext.getChargingStationContext(ContextDefinition.CHARGING_STATION_CONTEXTS.ASSIGNED_OCPP16 + '-' + ContextDefinition.SITE_CONTEXTS.SITE_BASIC + '-' + ContextDefinition.SITE_AREA_CONTEXTS.WITH_SMART_CHARGING_DC);
+    assert(!!this.chargingStationContext, 'Charging station context should not be null');
+    // Take into account the Charging Station location and its timezone
     const timezone = Utils.getTimezone(this.chargingStationContext.getChargingStation().coordinates);
     // The moment has to be cloned to have stable tests results!
     const atThatMoment = aParticularMoment.clone().tz(timezone);


### PR DESCRIPTION
'days of the week ' restriction now takes the timezone into account.

Hopefully we do not yet have charging stations at the 'Wallis and Futuna' location!
e.g.:  moment().tz("Pacific/Wallis").isoWeekday());