### PR TITLE
pricing - fix - mochatest create context

### DIFF
--- a/test/api/OCPPCommonTests.ts
+++ b/test/api/OCPPCommonTests.ts
@@ -6,6 +6,7 @@ import chai, { assert, expect } from 'chai';
 import CentralServerService from './client/CentralServerService';
 import ChargingStationContext from './context/ChargingStationContext';
 import Constants from '../../src/utils/Constants';
+import ContextDefinition from './context/ContextDefinition';
 import Factory from '../factories/Factory';
 import { OCPPStatus } from '../../src/types/ocpp/OCPPClient';
 import { StatusCodes } from 'http-status-codes';
@@ -29,7 +30,6 @@ export default class OCPPCommonTests {
   public centralUserService: CentralServerService;
 
   public currentPricingSetting;
-  public pricekWh = 2;
 
   public chargingStationConnector1: OCPPStatusNotificationRequest;
   public chargingStationConnector2: OCPPStatusNotificationRequest;
@@ -126,11 +126,6 @@ export default class OCPPCommonTests {
   }
 
   public async before(): Promise<void> {
-    const allSettings = await this.centralUserService.settingApi.readAll({});
-    this.currentPricingSetting = allSettings.data.result.find((s) => s.identifier === 'pricing');
-    if (this.currentPricingSetting) {
-      await this.centralUserService.updatePriceSetting(this.pricekWh, 'EUR');
-    }
     // Default Connector values
     this.chargingStationConnector1 = {
       connectorId: 1,
@@ -510,7 +505,7 @@ export default class OCPPCommonTests {
     for (let index = 0; index <= this.energyActiveImportMeterValues.length - 2; index++) {
       // Set new meter value
       currentCumulatedPrice = Utils.createDecimal(currentCumulatedPrice).plus(
-        Utils.computeSimplePrice(this.pricekWh, this.energyActiveImportMeterValues[index])).toNumber();
+        Utils.computeSimplePrice(ContextDefinition.DEFAULT_PRICE, this.energyActiveImportMeterValues[index])).toNumber();
       if (index === this.energyActiveImportMeterValues.length - 2) {
         this.totalPrice = currentCumulatedPrice;
       }
@@ -656,7 +651,7 @@ export default class OCPPCommonTests {
       }
     });
     // Check priced data
-    const totalTransactionPrice = Utils.computeSimplePrice(this.pricekWh, this.transactionTotalConsumptionWh);
+    const totalTransactionPrice = Utils.computeSimplePrice(ContextDefinition.DEFAULT_PRICE, this.transactionTotalConsumptionWh);
     assert(Utils.createDecimal(this.totalPrice).equals(totalTransactionPrice), `The total transaction price should be: ${totalTransactionPrice} - actual value is: ${this.totalPrice}`);
     // Check STOP priced data
     this.checkPricedTransactionData(transactionValidation.data);
@@ -691,7 +686,7 @@ export default class OCPPCommonTests {
       }
     });
     // Check priced data
-    const totalTransactionPrice = Utils.computeSimplePrice(this.pricekWh, this.transactionTotalConsumptionWh);
+    const totalTransactionPrice = Utils.computeSimplePrice(ContextDefinition.DEFAULT_PRICE, this.transactionTotalConsumptionWh);
     assert(this.totalPrice === totalTransactionPrice, `The total transaction price should be: ${totalTransactionPrice} - actual value is: ${this.totalPrice}`);
     // Check STOP priced data
     this.checkPricedTransactionData(response.data);

--- a/test/api/StatisticsTest.ts
+++ b/test/api/StatisticsTest.ts
@@ -72,7 +72,7 @@ describe('Statistics', function() {
     expectedInactivity = StatisticsContext.CONSTANTS.IDLE_MINUTES / 60;
 
     expectedTransactions = 1;
-    expectedPricing = 1 * expectedConsumption;
+    expectedPricing = ContextDefinition.DEFAULT_PRICE * expectedConsumption;
   });
 
   afterEach(() => {

--- a/test/api/TransactionCommonTests.ts
+++ b/test/api/TransactionCommonTests.ts
@@ -24,7 +24,6 @@ export default class TransactionCommonTests {
   public centralUserContext: any;
   public centralUserService: CentralServerService;
   public currentPricingSetting;
-  public pricekWh = 2;
   public transactionUser;
   public transactionUserService: CentralServerService;
 
@@ -57,14 +56,6 @@ export default class TransactionCommonTests {
     } else {
       this.transactionUserService = new CentralServerService(
         this.tenantContext.getTenant().subdomain, this.transactionUser);
-    }
-  }
-
-  public async before() {
-    const allSettings = await this.centralUserService.settingApi.readAll({});
-    this.currentPricingSetting = allSettings.data.result.find((s) => s.identifier === 'pricing');
-    if (this.currentPricingSetting) {
-      await this.centralUserService.updatePriceSetting(this.pricekWh, 'EUR');
     }
   }
 
@@ -390,7 +381,7 @@ export default class TransactionCommonTests {
     expect(transactions.data.stats).to.containSubset({
       totalConsumptionWattHours: 2000,
       totalDurationSecs: 7200,
-      totalPrice: 4,
+      totalPrice: 2,
       totalInactivitySecs: 0,
       count: 2
     }
@@ -453,7 +444,7 @@ export default class TransactionCommonTests {
     expect(transactions.data.stats).to.containSubset({
       totalConsumptionWattHours: 2000,
       totalPriceRefund: 0,
-      totalPricePending: 4,
+      totalPricePending: 2,
       currency: 'EUR',
       countRefundTransactions: 0,
       countPendingTransactions: 2,
@@ -1210,8 +1201,8 @@ export default class TransactionCommonTests {
         totalDurationSecs: 7 * 3600,
         totalInactivitySecs: 5 * 3600,
         inactivityStatus: InactivityStatus.ERROR,
-        price: 0.3,
-        roundedPrice: 0.3
+        price: 0.15,
+        roundedPrice: 0.15
       }
     });
   }

--- a/test/api/TransactionTest.ts
+++ b/test/api/TransactionTest.ts
@@ -52,7 +52,6 @@ describe('Transaction', function() {
 
       testData.chargingStationContext = testData.siteAreaContext.getChargingStationContext(ContextDefinition.CHARGING_STATION_CONTEXTS.ASSIGNED_OCPP16);
       testData.transactionCommonTests.setChargingStation(testData.chargingStationContext);
-      await testData.transactionCommonTests.before();
     });
 
     after(async () => {
@@ -372,7 +371,6 @@ describe('Transaction', function() {
 
       testData.chargingStationContext = testData.siteAreaContext.getChargingStationContext(ContextDefinition.CHARGING_STATION_CONTEXTS.ASSIGNED_OCPP16);
       testData.transactionCommonTests.setChargingStation(testData.chargingStationContext);
-      await testData.transactionCommonTests.before();
     });
 
     after(async () => {
@@ -575,7 +573,6 @@ describe('Transaction', function() {
 
       testData.chargingStationContext = testData.tenantContext.getChargingStationContext(ContextDefinition.CHARGING_STATION_CONTEXTS.UNASSIGNED_OCPP16);
       testData.transactionCommonTests.setChargingStation(testData.chargingStationContext);
-      await testData.transactionCommonTests.before();
     });
 
     after(async () => {

--- a/test/api/client/CentralServerService.ts
+++ b/test/api/client/CentralServerService.ts
@@ -132,28 +132,6 @@ export default class CentralServerService {
     return this._authenticatedUser.email;
   }
 
-  public async updatePriceSetting(pricekWh: number, priceUnit: string) {
-    const settings = await this.settingApi.readAll({});
-    let newSetting = false;
-    let setting: SettingDB = settings.data.result.find((s) => s.identifier === 'pricing');
-    if (!setting) {
-      setting = {} as SettingDB;
-      setting.identifier = TenantComponents.PRICING;
-      newSetting = true;
-    }
-    setting.content = {
-      type: PricingSettingsType.SIMPLE,
-      simple: {
-        price: pricekWh,
-        currency: priceUnit
-      }
-    };
-    if (newSetting) {
-      return this.settingApi.create(setting);
-    }
-    return this.settingApi.update(setting);
-  }
-
   public async createEntity(entityApi, entity, performCheck = true) {
     // Create
     const response = await entityApi.create(entity);

--- a/test/api/context/ContextBuilder.ts
+++ b/test/api/context/ContextBuilder.ts
@@ -1,4 +1,5 @@
 import ContextDefinition, { TenantDefinition } from './ContextDefinition';
+import PricingDefinition, { PricingEntity } from '../../../src/types/Pricing';
 import { SettingDB, SettingDBContent } from '../../../src/types/Setting';
 
 import AssetStorage from '../../../src/storage/mongodb/AssetStorage';
@@ -12,6 +13,7 @@ import OCPIEndpointStorage from '../../../src/storage/mongodb/OCPIEndpointStorag
 import { OCPIRegistrationStatus } from '../../../src/types/ocpi/OCPIRegistrationStatus';
 import { OCPIRole } from '../../../src/types/ocpi/OCPIRole';
 import OCPIUtils from '../../../src/server/ocpi/OCPIUtils';
+import PricingStorage from '../../../src/storage/mongodb/PricingStorage';
 import Site from '../../../src/types/Site';
 import SiteAreaStorage from '../../../src/storage/mongodb/SiteAreaStorage';
 import SiteContext from './SiteContext';
@@ -213,6 +215,22 @@ export default class ContextBuilder {
             token: 'TOIOP-OCPI-TOKEN-emsp-xxxx-xxxx-yyyy'
           } as OCPIEndpoint;
           await OCPIEndpointStorage.saveOcpiEndpoint(buildTenant, emspEndpoint);
+        } else if (componentSettingKey === TenantComponents.PRICING) {
+          // Create a default tariff (to replace the former Simple Pricing Logic)
+          const pricingDefinition: PricingDefinition = {
+            entityType: PricingEntity.TENANT,
+            entityID: buildTenant.id,
+            name: 'Main Tariff',
+            description: 'Tariff to emulate the former Simple Pricing Logic',
+            restrictions: null,
+            dimensions: {
+              energy: {
+                active: true,
+                price: 1,
+              }
+            }
+          } as PricingDefinition;
+          await PricingStorage.savePricingDefinition(buildTenant, pricingDefinition);
         }
       }
     }

--- a/test/api/context/ContextBuilder.ts
+++ b/test/api/context/ContextBuilder.ts
@@ -226,7 +226,7 @@ export default class ContextBuilder {
             dimensions: {
               energy: {
                 active: true,
-                price: 1,
+                price: ContextDefinition.DEFAULT_PRICE,
               }
             }
           } as PricingDefinition;

--- a/test/api/context/ContextDefinition.ts
+++ b/test/api/context/ContextDefinition.ts
@@ -99,6 +99,12 @@ export default class ContextDefinition {
     },
   };
 
+
+  /**
+   * Price of the consumed energy - 1 Euros / kWh
+   */
+  static readonly DEFAULT_PRICE = 1;
+
   /**
    * Definition of the different contexts
    */
@@ -111,7 +117,7 @@ export default class ContextDefinition {
         content: {
           type: PricingSettingsType.SIMPLE,
           simple: {
-            price: 1,
+            price: ContextDefinition.DEFAULT_PRICE,
             currency: 'EUR'
           }
         },
@@ -218,7 +224,7 @@ export default class ContextDefinition {
         content: {
           type: PricingSettingsType.SIMPLE,
           simple: {
-            price: 1,
+            price: ContextDefinition.DEFAULT_PRICE,
             currency: 'EUR'
           }
         }
@@ -302,7 +308,7 @@ export default class ContextDefinition {
         content: {
           type: PricingSettingsType.SIMPLE,
           simple: {
-            price: 1,
+            price: ContextDefinition.DEFAULT_PRICE,
             currency: 'EUR'
           }
         }


### PR DESCRIPTION
When the pricing module is ON
- A default tariff is created (price: 1 EUR/kWh) on all test tenants

This to make sure the test behaves as before when using the Simple Pricing logic.

Todo: cleanup some test helpers that are not used anymore !