### PR TITLE
Fixed tenant logo without Tenant's "LastChangedOn" property

### DIFF
--- a/src/storage/mongodb/CarStorage.ts
+++ b/src/storage/mongodb/CarStorage.ts
@@ -688,10 +688,10 @@ export default class CarStorage {
             $cond: {
               if: { $gt: ['$carCatalog.image', null] }, then: {
                 $concat: [
-                  `${Utils.buildRestServerURL()}/v1/util/CarCatalogImage?ID=`,
+                  `${Utils.buildRestServerURL()}/v1/util/car-catalogs/`,
                   '$carCatalog.id',
                   {
-                    $ifNull: [{ $concat: ['&LastChangedOn=', { $toString: '$carCatalog.lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
+                    $ifNull: [{ $concat: ['?LastChangedOn=', { $toString: '$carCatalog.lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
                   }
                 ]
               }, else: null

--- a/src/storage/mongodb/CarStorage.ts
+++ b/src/storage/mongodb/CarStorage.ts
@@ -108,10 +108,12 @@ export default class CarStorage {
             $cond: {
               if: { $gt: ['$image', null] }, then: {
                 $concat: [
-                  `${Utils.buildRestServerURL()}/client/util/CarCatalogImage?ID=`,
+                  `${Utils.buildRestServerURL()}/v1/util/car-catalogs/`,
                   { $toString: '$_id' },
-                  '&LastChangedOn=',
-                  { $toString: '$lastChangedOn' }
+                  '/image',
+                  {
+                    $ifNull: [{ $concat: ['?LastChangedOn=', { $toString: '$lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
+                  }
                 ]
               }, else: null
             }
@@ -686,10 +688,11 @@ export default class CarStorage {
             $cond: {
               if: { $gt: ['$carCatalog.image', null] }, then: {
                 $concat: [
-                  `${Utils.buildRestServerURL()}/client/util/CarCatalogImage?ID=`,
+                  `${Utils.buildRestServerURL()}/v1/util/CarCatalogImage?ID=`,
                   '$carCatalog.id',
-                  '&LastChangedOn=',
-                  { $toString: '$carCatalog.lastChangedOn' }
+                  {
+                    $ifNull: [{ $concat: ['&LastChangedOn=', { $toString: '$carCatalog.lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
+                  }
                 ]
               }, else: null
             }

--- a/src/storage/mongodb/CompanyStorage.ts
+++ b/src/storage/mongodb/CompanyStorage.ts
@@ -194,10 +194,13 @@ export default class CompanyStorage {
         $addFields: {
           logo: {
             $concat: [
-              `${Utils.buildRestServerURL()}/client/util/CompanyLogo?ID=`,
+              `${Utils.buildRestServerURL()}/v1/util/companies/`,
               { $toString: '$_id' },
-              `&TenantID=${tenant.id}&LastChangedOn=`,
-              { $toString: '$lastChangedOn' }
+              '/logo',
+              `?TenantID=${tenant.id}`,
+              {
+                $ifNull: [{ $concat: ['&LastChangedOn=', { $toString: '$lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
+              }
             ]
           }
         }

--- a/src/storage/mongodb/SiteAreaStorage.ts
+++ b/src/storage/mongodb/SiteAreaStorage.ts
@@ -278,10 +278,13 @@ export default class SiteAreaStorage {
         $addFields: {
           image: {
             $concat: [
-              `${Utils.buildRestServerURL()}/client/util/SiteAreaImage?ID=`,
+              `${Utils.buildRestServerURL()}/v1/util/site-areas/`,
               { $toString: '$_id' },
-              `&TenantID=${tenant.id}&LastChangedOn=`,
-              { $toString: '$lastChangedOn' }
+              '/image',
+              `?TenantID=${tenant.id}`,
+              {
+                $ifNull: [{ $concat: ['&LastChangedOn=', { $toString: '$lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
+              }
             ]
           }
         }

--- a/src/storage/mongodb/SiteStorage.ts
+++ b/src/storage/mongodb/SiteStorage.ts
@@ -442,10 +442,13 @@ export default class SiteStorage {
         $addFields: {
           image: {
             $concat: [
-              `${Utils.buildRestServerURL()}/client/util/SiteImage?ID=`,
+              `${Utils.buildRestServerURL()}/v1/util/sites/`,
               { $toString: '$_id' },
-              `&TenantID=${tenant.id}&LastChangedOn=`,
-              { $toString: '$lastChangedOn' }
+              '/image',
+              `?TenantID=${tenant.id}`,
+              {
+                $ifNull: [{ $concat: ['&LastChangedOn=', { $toString: '$lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
+              }
             ]
           }
         }

--- a/src/storage/mongodb/TenantStorage.ts
+++ b/src/storage/mongodb/TenantStorage.ts
@@ -191,7 +191,10 @@ export default class TenantStorage {
           logo: {
             $concat: [
               `${Utils.buildRestServerURL()}/v1/util/tenants/logo?ID=`,
-              { $toString: '$_id' }
+              { $toString: '$_id' },
+              {
+                $ifNull: [{ $concat: ['&LastChangedOn=', { $toString: '$lastChangedOn' }] }, ''] // Only concat 'lastChangedOn' if not null
+              }
             ]
           }
         }

--- a/src/storage/mongodb/TenantStorage.ts
+++ b/src/storage/mongodb/TenantStorage.ts
@@ -190,10 +190,8 @@ export default class TenantStorage {
         $addFields: {
           logo: {
             $concat: [
-              `${Utils.buildRestServerURL()}/client/util/TenantLogo?ID=`,
-              { $toString: '$_id' },
-              '&LastChangedOn=',
-              { $toString: '$lastChangedOn' }
+              `${Utils.buildRestServerURL()}/v1/util/tenants/logo?ID=`,
+              { $toString: '$_id' }
             ]
           }
         }


### PR DESCRIPTION
The Tenant's logo URL concatenation with "LastChangedOn" property fails if the tenant does not have the property. In addition, the parameter is not used in the `handleGetTenantLogo` method, so can be removed