### PR TITLE
pricing - repair sessions started the 7th dec and terminated the day after

### DIFF
--- a/src/migration/MigrationHandler.ts
+++ b/src/migration/MigrationHandler.ts
@@ -9,6 +9,7 @@ import MigrationStorage from '../storage/mongodb/MigrationStorage';
 import MigrationTask from './MigrationTask';
 import RemoveDuplicateTagVisualIDsTask from './tasks/RemoveDuplicateTagVisualIDsTask';
 import RepairInvoiceInconsistencies from './tasks/RepairInvoiceInconsistencies';
+import RepairTransactionPricedAtZero from './tasks/RepairTransactionPricedAtZeroTask';
 import RestoreDataIntegrityInSiteUsersTask from './tasks/RestoreDataIntegrityInSiteUsersTask';
 import { ServerAction } from '../types/Server';
 import SimplePricingMigrationTask from './tasks/MigrateSimplePricing';
@@ -93,6 +94,7 @@ export default class MigrationHandler {
     currentMigrationTasks.push(new AddUserIDToCarsTask());
     currentMigrationTasks.push(new RepairInvoiceInconsistencies());
     currentMigrationTasks.push(new SimplePricingMigrationTask());
+    currentMigrationTasks.push(new RepairTransactionPricedAtZero());
     currentMigrationTasks.push(new UpdateEmailsToLowercaseTask());
     return currentMigrationTasks;
   }

--- a/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
+++ b/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/member-ordering */
 import { PricingSettings, PricingSettingsType } from '../../types/Setting';
 import Tenant, { TenantComponents } from '../../types/Tenant';
 import global, { ActionsResponse } from '../../types/GlobalType';
@@ -13,13 +14,13 @@ import TransactionStorage from '../../storage/mongodb/TransactionStorage';
 import Utils from '../../utils/Utils';
 import chalk from 'chalk';
 
-const TASK_NAME = 'RepairTransactionPricedAtZeroTask';
+const MODULE_NAME = 'RepairTransactionPricedAtZero';
 
 export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
 
   pricingSettings: PricingSettings;
 
-  async loadSimplePricingSettings(tenant: Tenant): Promise<void> {
+  private async loadSimplePricingSettings(tenant: Tenant): Promise<void> {
     if (Utils.isTenantComponentActive(tenant, TenantComponents.PRICING)) {
       const pricingSettings = await SettingStorage.getPricingSettings(tenant);
       if (pricingSettings?.type === PricingSettingsType.SIMPLE) {
@@ -28,7 +29,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
     }
   }
 
-  async priceAllConsumptionsAgain(tenant: Tenant, transaction: Transaction): Promise<void> {
+  private async priceAllConsumptionsAgain(tenant: Tenant, transaction: Transaction): Promise<void> {
     const pricePerkWh = this.pricingSettings.simple.price;
     let cumulatedPrice = 0;
     // Get the consumptions
@@ -46,7 +47,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
     }
   }
 
-  async priceTransactionAgain(tenant: Tenant, transaction: Transaction): Promise<void> {
+  private async priceTransactionAgain(tenant: Tenant, transaction: Transaction): Promise<void> {
     const pricePerkWh = this.pricingSettings.simple.price;
     // Apply simple pricing logic
     const price = Utils.createDecimal(transaction.stop.totalConsumptionWh).mul(pricePerkWh).div(1000).toNumber();
@@ -57,7 +58,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  async migrateTenant(tenant: Tenant) {
+  public async migrateTenant(tenant: Tenant) {
     const transactionsUpdated: ActionsResponse = {
       inError: 0,
       inSuccess: 0,
@@ -87,7 +88,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
       await Logging.logInfo({
         tenantID: Constants.DEFAULT_TENANT,
         action: ServerAction.MIGRATION,
-        module: TASK_NAME, method: 'migrateTenant',
+        module: MODULE_NAME, method: 'migrateTenant',
         message,
       });
       Utils.isDevelopmentEnv() && console.debug(chalk.yellow(`${new Date().toISOString()} - ${message}`));
@@ -98,7 +99,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
           await Logging.logDebug({
             tenantID: Constants.DEFAULT_TENANT,
             action: ServerAction.MIGRATION,
-            module: TASK_NAME, method: 'migrateTenant',
+            module: MODULE_NAME, method: 'migrateTenant',
             message
           });
           Utils.isDevelopmentEnv() && console.debug(chalk.yellow(`${new Date().toISOString()} - ${message}`));
@@ -119,7 +120,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
           await Logging.logError({
             tenantID: Constants.DEFAULT_TENANT,
             action: ServerAction.MIGRATION,
-            module: TASK_NAME, method: 'migrateTenant',
+            module: MODULE_NAME, method: 'migrateTenant',
             message: `> ${transactionsUpdated.inError + transactionsUpdated.inSuccess}/${transactionsMDB.length} - Cannot price transaction: '${transactionMDB._id}' in Tenant ${Utils.buildTenantName(tenant)}`,
             detailedMessages: { error: error.message, stack: error.stack }
           });
@@ -128,7 +129,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
         const totalDurationSecs = Math.trunc((new Date().getTime() - timeTotalFrom) / 1000);
         // Log in the default tenant
         void Logging.logActionsResponse(Constants.DEFAULT_TENANT, ServerAction.MIGRATION,
-          TASK_NAME, 'migrateTenant', transactionsUpdated,
+          MODULE_NAME, 'migrateTenant', transactionsUpdated,
           `{{inSuccess}} transaction(s) were successfully processed in ${totalDurationSecs} secs in Tenant ${Utils.buildTenantName(tenant)}`,
           `{{inError}} transaction(s) failed to be processed in ${totalDurationSecs} secs in Tenant ${Utils.buildTenantName(tenant)}`,
           `{{inSuccess}} transaction(s) were successfully processed in ${totalDurationSecs} secs and {{inError}} failed to be processed in Tenant ${Utils.buildTenantName(tenant)}`,
@@ -138,15 +139,15 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
     }
   }
 
-  getVersion(): string {
+  public getVersion(): string {
     return '1.0';
   }
 
-  getName(): string {
-    return TASK_NAME;
+  public getName(): string {
+    return 'RepairTransactionPricedAtZeroTask';
   }
 
-  isAsynchronous(): boolean {
+  public isAsynchronous(): boolean {
     return true;
   }
 }

--- a/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
+++ b/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
@@ -1,0 +1,154 @@
+import { PricingSettings, PricingSettingsType } from '../../types/Setting';
+import Tenant, { TenantComponents } from '../../types/Tenant';
+import global, { ActionsResponse } from '../../types/GlobalType';
+
+import Constants from '../../utils/Constants';
+import ConsumptionStorage from '../../storage/mongodb/ConsumptionStorage';
+import Logging from '../../utils/Logging';
+import { ServerAction } from '../../types/Server';
+import SettingStorage from '../../storage/mongodb/SettingStorage';
+import TenantMigrationTask from '../TenantMigrationTask';
+import Transaction from '../../types/Transaction';
+import TransactionStorage from '../../storage/mongodb/TransactionStorage';
+import Utils from '../../utils/Utils';
+import chalk from 'chalk';
+
+const TASK_NAME = 'RepairTransactionPricedAtZeroTask';
+
+export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
+
+  pricingSettings: PricingSettings;
+
+  async loadSimplePricingSettings(tenant: Tenant): Promise<void> {
+    if (Utils.isTenantComponentActive(tenant, TenantComponents.PRICING)) {
+      // Get the billing's settings
+      const pricingSettings = await SettingStorage.getPricingSettings(tenant);
+      if (pricingSettings?.type === PricingSettingsType.SIMPLE) {
+        this.pricingSettings = pricingSettings;
+      }
+    }
+  }
+
+  async priceAllConsumptionsAgain(tenant: Tenant, transaction: Transaction): Promise<void> {
+    const pricePerkWh = this.pricingSettings.simple.price;
+    let cumulatedPrice = 0;
+    // Get the consumptions
+    const consumptionDataResult = await ConsumptionStorage.getTransactionConsumptions(tenant, { transactionId: transaction.id });
+    const consumptions = consumptionDataResult.result;
+    for (const consumption of consumptions) {
+      // Update the price
+      const amount = Utils.computeSimplePrice(pricePerkWh, consumption.consumptionWh);
+      cumulatedPrice = Utils.createDecimal(cumulatedPrice).plus(amount).toNumber();
+      consumption.amount = amount;
+      consumption.roundedAmount = Utils.truncTo(amount, 2);
+      consumption.cumulatedAmount = cumulatedPrice;
+      // Update the consumption
+      await ConsumptionStorage.saveConsumption(tenant, consumption);
+    }
+  }
+
+  async priceTransactionAgain(tenant: Tenant, transaction: Transaction): Promise<void> {
+    const pricePerkWh = this.pricingSettings.simple.price;
+    // Apply simple pricing logic
+    const price = Utils.createDecimal(transaction.stop.totalConsumptionWh).mul(pricePerkWh).div(1000).toNumber();
+    transaction.stop.price = price;
+    transaction.stop.roundedPrice = Utils.truncTo(price, 2);
+    // Save
+    await TransactionStorage.saveTransaction(tenant, transaction);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  async migrateTenant(tenant: Tenant) {
+    const transactionsUpdated: ActionsResponse = {
+      inError: 0,
+      inSuccess: 0,
+    };
+    const timeTotalFrom = new Date().getTime();
+    // Get transactions
+    const transactionsMDB = await global.database.getCollection<any>(tenant.id, 'transactions')
+      .aggregate([
+        {
+          $match: {
+            'timestamp': { $gt: new Date('2021-12-07') },
+            'stop.timestamp': { $lt: new Date('2021-12-09') },
+            'stop.price': 0,
+            'stop.totalConsumptionWh': { $gt: 0 } ,
+            'stop.pricingSource': 'simple',
+            'refundData': { $exists: false }
+          }
+        },
+        {
+          $project: { '_id': 1 }
+        }
+      ]).toArray();
+
+    // Get Simple Pricing Price
+    await this.loadSimplePricingSettings(tenant);
+    if (transactionsMDB.length > 0 && this.pricingSettings?.simple?.price > 0) {
+      let message = `${transactionsMDB.length} Transaction(s) are going to be repaired in Tenant ${Utils.buildTenantName(tenant)}...`;
+      await Logging.logInfo({
+        tenantID: Constants.DEFAULT_TENANT,
+        action: ServerAction.MIGRATION,
+        module: TASK_NAME, method: 'migrateTenant',
+        message,
+      });
+      Utils.isDevelopmentEnv() && console.debug(chalk.yellow(`${new Date().toISOString()} - ${message}`));
+      await Promise.map(transactionsMDB, async (transactionMDB) => {
+        const numberOfProcessedTransactions = transactionsUpdated.inError + transactionsUpdated.inSuccess;
+        if (numberOfProcessedTransactions > 0 && (numberOfProcessedTransactions % 100) === 0) {
+          message = `> ${transactionsUpdated.inError + transactionsUpdated.inSuccess}/${transactionsMDB.length} - Transaction consumptions recomputed in Tenant ${Utils.buildTenantName(tenant)}`;
+          await Logging.logDebug({
+            tenantID: Constants.DEFAULT_TENANT,
+            action: ServerAction.MIGRATION,
+            module: TASK_NAME, method: 'migrateTenant',
+            message
+          });
+          Utils.isDevelopmentEnv() && console.debug(chalk.yellow(`${new Date().toISOString()} - ${message}`));
+        }
+        try {
+          // Get the transaction
+          const transaction = await TransactionStorage.getTransaction(tenant, transactionMDB._id);
+          // Transaction to be repaired to not have a pricing model
+          if (!transaction.pricingModel) {
+            // Price the consumptions again
+            await this.priceAllConsumptionsAgain(tenant, transaction);
+            // Price the transaction again
+            await this.priceTransactionAgain(tenant, transaction);
+          }
+          transactionsUpdated.inSuccess++;
+        } catch (error) {
+          transactionsUpdated.inError++;
+          await Logging.logError({
+            tenantID: Constants.DEFAULT_TENANT,
+            action: ServerAction.MIGRATION,
+            module: TASK_NAME, method: 'migrateTenant',
+            message: `> ${transactionsUpdated.inError + transactionsUpdated.inSuccess}/${transactionsMDB.length} - Cannot price transaction: '${transactionMDB._id}' in Tenant ${Utils.buildTenantName(tenant)}`,
+            detailedMessages: { error: error.message, stack: error.stack }
+          });
+        }
+      }, { concurrency: 5 }).then(() => {
+        const totalDurationSecs = Math.trunc((new Date().getTime() - timeTotalFrom) / 1000);
+        // Log in the default tenant
+        void Logging.logActionsResponse(Constants.DEFAULT_TENANT, ServerAction.MIGRATION,
+          TASK_NAME, 'migrateTenant', transactionsUpdated,
+          `{{inSuccess}} transaction(s) were successfully processed in ${totalDurationSecs} secs in Tenant ${Utils.buildTenantName(tenant)}`,
+          `{{inError}} transaction(s) failed to be processed in ${totalDurationSecs} secs in Tenant ${Utils.buildTenantName(tenant)}`,
+          `{{inSuccess}} transaction(s) were successfully processed in ${totalDurationSecs} secs and {{inError}} failed to be processed in Tenant ${Utils.buildTenantName(tenant)}`,
+          `All the transactions are up to date in Tenant ${Utils.buildTenantName(tenant)}`
+        );
+      });
+    }
+  }
+
+  getVersion(): string {
+    return '1.0';
+  }
+
+  getName(): string {
+    return TASK_NAME;
+  }
+
+  isAsynchronous(): boolean {
+    return true;
+  }
+}

--- a/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
+++ b/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
@@ -21,7 +21,6 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
 
   async loadSimplePricingSettings(tenant: Tenant): Promise<void> {
     if (Utils.isTenantComponentActive(tenant, TenantComponents.PRICING)) {
-      // Get the billing's settings
       const pricingSettings = await SettingStorage.getPricingSettings(tenant);
       if (pricingSettings?.type === PricingSettingsType.SIMPLE) {
         this.pricingSettings = pricingSettings;
@@ -81,8 +80,7 @@ export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
           $project: { '_id': 1 }
         }
       ]).toArray();
-
-    // Get Simple Pricing Price
+    // Load Simple Pricing Settings
     await this.loadSimplePricingSettings(tenant);
     if (transactionsMDB.length > 0 && this.pricingSettings?.simple?.price > 0) {
       let message = `${transactionsMDB.length} Transaction(s) are going to be repaired in Tenant ${Utils.buildTenantName(tenant)}...`;

--- a/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
+++ b/src/migration/tasks/RepairTransactionPricedAtZeroTask.ts
@@ -17,7 +17,6 @@ import chalk from 'chalk';
 const MODULE_NAME = 'RepairTransactionPricedAtZero';
 
 export default class RepairTransactionPricedAtZero extends TenantMigrationTask {
-
   pricingSettings: PricingSettings;
 
   private async loadSimplePricingSettings(tenant: Tenant): Promise<void> {


### PR DESCRIPTION
Migration task to fix sessions that have been priced at zero because they were started with the "simple pricing logic" and terminated with the "built-in pricing engine".

This mainly impact the sessions of the slfcah (charge at home). But some other tenants may have the same issue.
The migration task simply price again the transaction and the corresponding consumption data.