### PR TITLE
Allow to not pass mobile phone to report error (API call)

### DIFF
--- a/src/assets/server/rest/v1/schemas/notification/notifications-end-user-error-report.json
+++ b/src/assets/server/rest/v1/schemas/notification/notifications-end-user-error-report.json
@@ -12,7 +12,7 @@
       "sanitize": "mongo"
     },
     "mobile": {
-      "type": "string",
+      "type": ["string", "null"],
       "sanitize": "mongo",
       "pattern": "^\\+?([0-9] ?){9,14}[0-9]$"
     }

--- a/src/server/rest/v1/service/NotificationService.ts
+++ b/src/server/rest/v1/service/NotificationService.ts
@@ -63,16 +63,11 @@ export default class NotificationService {
     // Check and Get User
     const user = await UtilsService.checkAndGetUserAuthorization(
       req.tenant, req.user, req.user.id, Action.READ, action);
-    // Save mobile number
-    if (filteredRequest.mobile && user.mobile !== filteredRequest.mobile) {
-      user.mobile = filteredRequest.mobile;
-      await UserStorage.saveUserMobilePhone(req.tenant, user.id, { mobile: filteredRequest.mobile });
-    }
     // Set
     const endUserErrorNotification: EndUserErrorNotification = {
       userID: user.id,
       email: user.email,
-      phone: user.mobile,
+      phone: filteredRequest?.mobile ?? user?.mobile,
       name: Utils.buildUserFullName(user, false, false),
       errorTitle: filteredRequest.subject,
       errorDescription: filteredRequest.description,


### PR DESCRIPTION
Allow to not pass mobile phone to report error (to debug mobile app)
Also, the mobile number is already fetched server-side when the request is processed