### PR TITLE
pricing - prevent flat fee if no consumption

### DIFF
--- a/src/integration/pricing/ConsumptionChunkPricer.ts
+++ b/src/integration/pricing/ConsumptionChunkPricer.ts
@@ -129,13 +129,20 @@ export default class ConsumptionChunkPricer {
     if (!this.getPricingModel().pricerContext.flatFeeAlreadyPriced) {
       const activePricingDefinition = this.getActiveDefinition4Dimension(this.actualPricingDefinitions, DimensionType.FLAT_FEE);
       if (activePricingDefinition) {
-        const dimensionToPrice = activePricingDefinition.dimensions.flatFee;
-        const pricedData = this.priceFlatFeeDimension(dimensionToPrice);
-        if (pricedData) {
-          pricedData.sourceName = activePricingDefinition.name;
-          this.getPricingModel().pricerContext.flatFeeAlreadyPriced = true;
+        // --------------------------------------------------------------------------------
+        // Make sure not to price the Flat Fee when no energy has been delivered
+        // End-users may attempt to plug/unplug several times their car, without charging
+        // In such situation, they should not pay !
+        // -------------------------------------------------------------------------------
+        if (this.consumptionChunk.cumulatedConsumptionWh > 0) {
+          const dimensionToPrice = activePricingDefinition.dimensions.flatFee;
+          const pricedData = this.priceFlatFeeDimension(dimensionToPrice);
+          if (pricedData) {
+            pricedData.sourceName = activePricingDefinition.name;
+            this.getPricingModel().pricerContext.flatFeeAlreadyPriced = true;
+          }
+          return pricedData;
         }
-        return pricedData;
       }
     }
   }


### PR DESCRIPTION
I would like to change the logic for the **flat fee** and make sure we do not bill it if no energy has been delivered.

The purpose of that change is to make sure the end-user **do not pay several times** the Flat Fee, when he plugs/unplugs his car several times without charging at all.

