### PR TITLE
Issuer filter cleanup

### DIFF
--- a/src/authorization/AuthorizationsDefinition.ts
+++ b/src/authorization/AuthorizationsDefinition.ts
@@ -31,12 +31,26 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
           Fn: 'custom:dynamicAuthorizations',
           args: {
             asserts: [],
-            filters: ['-OwnUser']
+            filters: ['-OwnUser', 'LocalIssuer']
           }
         }
       },
       {
-        resource: Entity.USER, action: [Action.READ, Action.CREATE, Action.UPDATE],
+        resource: Entity.USER, action: [Action.READ, Action.CREATE],
+        attributes: [
+          'id', 'name', 'firstName', 'email', 'role', 'status', 'issuer', 'locale', 'plateID',
+          'notificationsActive', 'notifications', 'phone', 'mobile', 'iNumber', 'costCenter', 'address'
+        ]
+      },
+      {
+        resource: Entity.USER, action: Action.UPDATE,
+        condition: {
+          Fn: 'custom:dynamicAuthorizations',
+          args: {
+            asserts: [],
+            filters: ['LocalIssuer']
+          }
+        },
         attributes: [
           'id', 'name', 'firstName', 'email', 'role', 'status', 'issuer', 'locale', 'plateID',
           'notificationsActive', 'notifications', 'phone', 'mobile', 'iNumber', 'costCenter', 'address'
@@ -123,12 +137,26 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
           Fn: 'custom:dynamicAuthorizations',
           args: {
             asserts: [],
-            filters: ['-OwnUser']
+            filters: ['-OwnUser', 'LocalIssuer']
           }
         }
       },
       {
-        resource: Entity.USER, action: [Action.READ, Action.CREATE, Action.UPDATE],
+        resource: Entity.USER, action: [Action.READ, Action.CREATE],
+        attributes: [
+          'id', 'name', 'firstName', 'email', 'role', 'status', 'issuer', 'locale', 'plateID',
+          'notificationsActive', 'notifications', 'phone', 'mobile', 'iNumber', 'costCenter', 'address', 'technical', 'freeAccess'
+        ]
+      },
+      {
+        resource: Entity.USER, action: Action.UPDATE,
+        condition: {
+          Fn: 'custom:dynamicAuthorizations',
+          args: {
+            asserts: [],
+            filters: ['LocalIssuer']
+          }
+        },
         attributes: [
           'id', 'name', 'firstName', 'email', 'role', 'status', 'issuer', 'locale', 'plateID',
           'notificationsActive', 'notifications', 'phone', 'mobile', 'iNumber', 'costCenter', 'address', 'technical', 'freeAccess'
@@ -152,12 +180,29 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
       { resource: Entity.TAG, action: [Action.IMPORT, Action.EXPORT] },
       {
         resource: Entity.TAG, action: Action.READ,
+        condition: {
+          Fn: 'custom:dynamicAuthorizations',
+          args: {
+            asserts: [],
+            filters: ['LocalIssuer'],
+          }
+        },
         attributes: [
           'id', 'userID', 'issuer', 'active', 'description', 'visualID', 'default', 'user.id',
           'user.name', 'user.firstName', 'user.email'
         ]
       },
-      { resource: Entity.TAG, action: [Action.CREATE, Action.UPDATE, Action.DELETE] },
+      {
+        resource: Entity.TAG, action: [Action.UPDATE, Action.DELETE],
+        condition: {
+          Fn: 'custom:dynamicAuthorizations',
+          args: {
+            asserts: [],
+            filters: ['LocalIssuer'],
+          }
+        }
+      },
+      { resource: Entity.TAG, action: Action.CREATE },
       { resource: Entity.CHARGING_PROFILE, action: Action.LIST },
       { resource: Entity.CHARGING_PROFILE, action: [Action.READ] },
       {
@@ -761,6 +806,13 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
       },
       {
         resource: Entity.TAG, action: Action.ASSIGN,
+        condition: {
+          Fn: 'custom:dynamicAuthorizations',
+          args: {
+            asserts: [],
+            filters: ['LocalIssuer']
+          }
+        },
         attributes: [
           'userID', 'description', 'visualID', 'default',
           'user.name', 'user.firstName', 'user.email', 'createdOn', 'lastChangedOn'
@@ -988,12 +1040,26 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
         ],
       },
       {
-        resource: Entity.USER, action: [Action.CREATE, Action.UPDATE],
+        resource: Entity.USER, action: Action.CREATE,
         condition: {
           Fn: 'custom:dynamicAuthorizations',
           args: {
             asserts: ['BasicUser'],
             filters: ['SitesAdmin'],
+          }
+        },
+        attributes: [
+          'id', 'name', 'firstName', 'email', 'role', 'status', 'issuer', 'locale', 'plateID',
+          'notificationsActive', 'notifications', 'phone', 'mobile', 'iNumber', 'costCenter', 'address', 'technical'
+        ],
+      },
+      {
+        resource: Entity.USER, action: Action.UPDATE,
+        condition: {
+          Fn: 'custom:dynamicAuthorizations',
+          args: {
+            asserts: ['BasicUser'],
+            filters: ['SitesAdmin', 'LocalIssuer'],
           }
         },
         attributes: [
@@ -1008,7 +1074,7 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
           Fn: 'custom:dynamicAuthorizations',
           args: {
             asserts: ['BasicUser'],
-            filters: ['-OwnUser', 'SitesAdmin']
+            filters: ['-OwnUser', 'SitesAdmin', 'LocalIssuer']
           }
         }
       },

--- a/src/server/rest/v1/service/AuthorizationService.ts
+++ b/src/server/rest/v1/service/AuthorizationService.ts
@@ -223,17 +223,13 @@ export default class AuthorizationService {
   }
 
   public static async addUserAuthorizations(tenant: Tenant, userToken: UserToken, user: User, authorizationFilter: AuthorizationFilter): Promise<void> {
-    if (!user.issuer) {
-      user.canRead = true;
-    } else {
-      user.canRead = true; // Always true as it should be filtered upfront
-      user.canUpdate = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.USER, Action.UPDATE, authorizationFilter, { UserID: user.id }, user);
-      user.canDelete = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.USER, Action.DELETE, authorizationFilter, { UserID: user.id }, user);
-      // Optimize data over the net
-      Utils.removeCanPropertiesWithFalseValue(user);
-    }
+    user.canRead = true; // Always true as it should be filtered upfront
+    user.canUpdate = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.USER, Action.UPDATE, authorizationFilter, { UserID: user.id }, user);
+    user.canDelete = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.USER, Action.DELETE, authorizationFilter, { UserID: user.id }, user);
+    // Optimize data over the net
+    Utils.removeCanPropertiesWithFalseValue(user);
   }
 
   public static async checkAndGetUsersAuthorizations(tenant: Tenant, userToken: UserToken,
@@ -340,25 +336,21 @@ export default class AuthorizationService {
   }
 
   public static async addTagAuthorizations(tenant: Tenant, userToken: UserToken, tag: Tag, authorizationFilter: AuthorizationFilter): Promise<void> {
-    if (!tag.issuer) {
-      tag.canRead = true;
-    } else {
-      tag.canRead = true; // Always true as it should be filtered upfront
-      tag.canDelete = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.TAG, Action.DELETE, authorizationFilter, { TagID: tag.id }, tag);
-      tag.canUpdate = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.TAG, Action.UPDATE, authorizationFilter, { TagID: tag.id }, tag);
-      tag.canUpdateByVisualID = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.TAG, Action.UPDATE_BY_VISUAL_ID, authorizationFilter, { TagID: tag.id }, tag);
-      tag.canUnassign = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.TAG, Action.UNASSIGN, authorizationFilter, { TagID: tag.id }, tag);
-      tag.canAssign = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.TAG, Action.ASSIGN, authorizationFilter, { TagID: tag.id }, tag);
-      tag.canListUsers = await AuthorizationService.canPerformAuthorizationAction(
-        tenant, userToken, Entity.USER, Action.LIST, authorizationFilter);
-      // Optimize data over the net
-      Utils.removeCanPropertiesWithFalseValue(tag);
-    }
+    tag.canRead = true; // Always true as it should be filtered upfront
+    tag.canDelete = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.TAG, Action.DELETE, authorizationFilter, { TagID: tag.id }, tag);
+    tag.canUpdate = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.TAG, Action.UPDATE, authorizationFilter, { TagID: tag.id }, tag);
+    tag.canUpdateByVisualID = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.TAG, Action.UPDATE_BY_VISUAL_ID, authorizationFilter, { TagID: tag.id }, tag);
+    tag.canUnassign = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.TAG, Action.UNASSIGN, authorizationFilter, { TagID: tag.id }, tag);
+    tag.canAssign = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.TAG, Action.ASSIGN, authorizationFilter, { TagID: tag.id }, tag);
+    tag.canListUsers = await AuthorizationService.canPerformAuthorizationAction(
+      tenant, userToken, Entity.USER, Action.LIST, authorizationFilter);
+    // Optimize data over the net
+    Utils.removeCanPropertiesWithFalseValue(tag);
   }
 
   public static async checkAndGetRegistrationTokenAuthorizations(tenant: Tenant, userToken: UserToken,

--- a/src/storage/mongodb/TagStorage.ts
+++ b/src/storage/mongodb/TagStorage.ts
@@ -240,25 +240,28 @@ export default class TagStorage {
   }
 
   public static async getTag(tenant: Tenant, id: string,
-      params: { userIDs?: string[], withUser?: boolean; withNbrTransactions?: boolean; active?: boolean; siteIDs?: string[]; } = {}, projectFields?: string[]): Promise<Tag> {
+      params: { userIDs?: string[], withUser?: boolean, withNbrTransactions?: boolean, active?: boolean, siteIDs?: string[], issuer?: boolean } = {},
+      projectFields?: string[]): Promise<Tag> {
     const tagMDB = await TagStorage.getTags(tenant, {
       tagIDs: [id],
       withUser: params.withUser,
       withNbrTransactions: params.withNbrTransactions,
       userIDs: params.userIDs,
       active: params.active,
-      siteIDs: params.siteIDs
+      siteIDs: params.siteIDs,
+      issuer: params.issuer,
     }, Constants.DB_PARAMS_SINGLE_RECORD, projectFields);
     return tagMDB.count === 1 ? tagMDB.result[0] : null;
   }
 
   public static async getTagByVisualID(tenant: Tenant, visualID: string,
-      params: { withUser?: boolean; withNbrTransactions?: boolean, userIDs?: string[] } = {}, projectFields?: string[]): Promise<Tag> {
+      params: { withUser?: boolean, withNbrTransactions?: boolean, userIDs?: string[], issuer?: boolean } = {}, projectFields?: string[]): Promise<Tag> {
     const tagMDB = await TagStorage.getTags(tenant, {
       visualIDs: [visualID],
       withUser: params.withUser,
       withNbrTransactions: params.withNbrTransactions,
-      userIDs: params.userIDs
+      userIDs: params.userIDs,
+      issuer: params.issuer
     }, Constants.DB_PARAMS_SINGLE_RECORD, projectFields);
     return tagMDB.count === 1 ? tagMDB.result[0] : null;
   }


### PR DESCRIPTION
Goal of this PR:
- Move issuer check in auth definition when possible
- Update Auth definition with issuer constraint on actions

I added 2 TODOs:
- checkAndGetUserAuthorization is used in multiple components and sometimes we call the function for USER and READ action with checkIssuer = true or false which should bypass the LocalIssuer filter. Because of this we cannot update the auth definition for USER Action.READ and I don't know if the checkIssuer was put in place due to limitations I don't see !
- checkAndGetChargingStationAuthorization not using yet the new auth, so cannot move the issuer check yet.