### PR TITLE
billing - check free access before checking customerID

### DIFF
--- a/src/integration/billing/BillingFacade.ts
+++ b/src/integration/billing/BillingFacade.ts
@@ -14,7 +14,7 @@ const MODULE_NAME = 'BillingFacade';
 
 export default class BillingFacade {
   public static async processStartTransaction(tenant: Tenant, transaction: Transaction, chargingStation: ChargingStation, siteArea: SiteArea, user: User): Promise<void> {
-    if (!user?.issuer || user.freeAccess) {
+    if (!user?.issuer) {
       return;
     }
     const billingImpl = await BillingFactory.getBillingImpl(tenant);
@@ -53,7 +53,7 @@ export default class BillingFacade {
   }
 
   public static async processUpdateTransaction(tenant: Tenant, transaction: Transaction, user: User): Promise<void> {
-    if (!user?.issuer || user.freeAccess) {
+    if (!user?.issuer) {
       return;
     }
     const billingImpl = await BillingFactory.getBillingImpl(tenant);
@@ -78,7 +78,7 @@ export default class BillingFacade {
   }
 
   public static async processStopTransaction(tenant: Tenant, transaction: Transaction, user: User): Promise<void> {
-    if (!user?.issuer || user.freeAccess) {
+    if (!user?.issuer) {
       return;
     }
     const billingImpl = await BillingFactory.getBillingImpl(tenant);
@@ -104,7 +104,7 @@ export default class BillingFacade {
   }
 
   public static async processEndTransaction(tenant: Tenant, transaction: Transaction, user: User): Promise<void> {
-    if (!user?.issuer || user.freeAccess) {
+    if (!user?.issuer) {
       return;
     }
     const billingImpl = await BillingFactory.getBillingImpl(tenant);

--- a/src/integration/billing/BillingIntegration.ts
+++ b/src/integration/billing/BillingIntegration.ts
@@ -243,14 +243,9 @@ export default abstract class BillingIntegration {
         action: ServerAction.BILLING_TRANSACTION
       });
     }
-    // Check Billing Data
-    if (!transaction.user?.billingData?.customerID) {
-      throw new BackendError({
-        message: 'User has no Billing data or no Customer ID',
-        module: MODULE_NAME,
-        method: 'checkStartTransaction',
-        action: ServerAction.BILLING_TRANSACTION
-      });
+    // Check Free Access
+    if (transaction.user.freeAccess) {
+      return false;
     }
     if (!chargingStation) {
       throw new BackendError({
@@ -274,9 +269,14 @@ export default abstract class BillingIntegration {
         return false;
       }
     }
-    // Check Free Access
-    if (transaction.user.freeAccess) {
-      return false;
+    // Check Billing Data
+    if (!transaction.user?.billingData?.customerID) {
+      throw new BackendError({
+        message: 'User has no Billing data or no Customer ID',
+        module: MODULE_NAME,
+        method: 'checkStartTransaction',
+        action: ServerAction.BILLING_TRANSACTION
+      });
     }
     return true;
   }


### PR DESCRIPTION
Free Access:

- Putting back the check of the free access to the **BillingAbstraction.checkStartTransaction()** METHOD
- Moved down the check of the stripe **customerID** 

Note: This also impacts the check of the "siteArea.accessControl" flag! - we potencially had the same problem!