### PR TITLE
Transaction - consumptions - add priceUnit to projection

### DIFF
--- a/src/server/rest/v1/service/TransactionService.ts
+++ b/src/server/rest/v1/service/TransactionService.ts
@@ -379,7 +379,7 @@ export default class TransactionService {
       'currentTotalDurationSecs', 'currentTotalInactivitySecs', 'currentInstantWatts', 'currentTotalConsumptionWh', 'currentStateOfCharge', 'currentInactivityStatus',
       'stop.roundedPrice', 'stop.price', 'stop.priceUnit', 'stop.inactivityStatus', 'stop.stateOfCharge', 'stop.timestamp', 'stop.totalConsumptionWh',
       'stop.totalDurationSecs', 'stop.totalInactivitySecs', 'stop.extraInactivitySecs', 'stop.pricingSource', 'stop.reason',
-      'userID',
+      'userID', 'priceUnit'
     ];
     // Check Cars
     if (Utils.isComponentActiveFromToken(req.user, TenantComponents.CAR)) {


### PR DESCRIPTION
The mobile app needs the currency code when displaying the amount curve in the session chart.
This information was not part of the projection!