### PR TITLE
Pricing - inconsistent price when step is set

### DIFF
--- a/test/api/BillingTest.ts
+++ b/test/api/BillingTest.ts
@@ -2,8 +2,8 @@
 import { BillingChargeInvoiceAction, BillingInvoiceStatus } from '../../src/types/Billing';
 import { BillingSettings, BillingSettingsType } from '../../src/types/Setting';
 import chai, { expect } from 'chai';
-import { BillingPeriodicOperationTaskConfig } from '../../src/types/TaskConfig';
 
+import { BillingPeriodicOperationTaskConfig } from '../../src/types/TaskConfig';
 import BillingTestHelper from './BillingTestHelper';
 import CentralServerService from './client/CentralServerService';
 import Constants from '../../src/utils/Constants';
@@ -666,6 +666,17 @@ describeif(isBillingProperlyConfigured)('Billing', () => {
           assert(transactionID, 'transactionID should not be null');
           // Check that we have a new invoice with an invoiceID and an invoiceNumber
           await billingTestHelper.checkTransactionBillingData(transactionID, BillingInvoiceStatus.PAID, 29.49);
+        });
+
+        it('should bill the ENERGY + CT(STEP80S) on COMBO CCS - DC', async () => {
+          await billingTestHelper.initChargingStationContext2TestFastCharger('E+CT(STEP80S)');
+          await billingTestHelper.userService.billingApi.forceSynchronizeUser({ id: billingTestHelper.userContext.id });
+          const userWithBillingData = await billingTestHelper.billingImpl.getUser(billingTestHelper.userContext);
+          await billingTestHelper.assignPaymentMethod(userWithBillingData, 'tok_fr');
+          const transactionID = await billingTestHelper.generateTransaction(billingTestHelper.userContext);
+          assert(transactionID, 'transactionID should not be null');
+          // Check that we have a new invoice with an invoiceID and an invoiceNumber
+          await billingTestHelper.checkTransactionBillingData(transactionID, BillingInvoiceStatus.PAID, 10.11);
         });
 
         it('should bill the FF+E with 2 tariffs on COMBO CCS - DC', async () => {

--- a/test/api/BillingTestHelper.ts
+++ b/test/api/BillingTestHelper.ts
@@ -212,6 +212,18 @@ export default class BillingTestHelper {
           active: true
         }
       };
+    } else if (testMode === 'E+CT(STEP80S)') {
+      dimensions = {
+        energy: {
+          price: 0.30,
+          active: true
+        },
+        chargingTime: {
+          price: 0.60, // Euro per hour
+          stepSize: 80, // 1 minute + 20 seconds
+          active: true
+        }
+      };
     } else if (testMode === 'E-After30mins+PT') {
       // Create a second tariff with a different pricing strategy
       dimensions = {


### PR DESCRIPTION
Pricing the charging time gives inconsistent results when the meter values pace and the step size are different.

The typical situation where the result is unpredictable is the one below:
- Charging station sends data every 56 seconds.
- Pricing definition is set to price the chatting time every minute (60s).

With the current logic, some steps are not priced at all. The final price is simply wrong because some seconds are skipped .
Known workaround: 
- Get rid of the step size in the pricing definition. A step size of 60 seconds is simply useless!


Example of wrong data:
<img width="786" alt="2022-04-05_15-32-42" src="https://user-images.githubusercontent.com/26900551/161765915-89c52790-5de3-4e22-af72-27eeb1f26c27.png">


