### PR TITLE
Billing - convert invoiceID to ObjectID

### DIFF
--- a/src/storage/mongodb/TransactionStorage.ts
+++ b/src/storage/mongodb/TransactionStorage.ts
@@ -1326,17 +1326,20 @@ export default class TransactionStorage {
   }
 
   private static normalizeBillingData(billingData: TransactionBillingData): any {
-    return {
-      withBillingActive: billingData.withBillingActive,
-      lastUpdate: Utils.convertToDate(billingData.lastUpdate),
-      stop: {
-        status: billingData.stop?.status,
-        invoiceID: DatabaseUtils.convertToObjectID(billingData.stop?.invoiceID),
-        invoiceNumber: billingData.stop?.invoiceNumber,
-        invoiceStatus: billingData.stop?.invoiceStatus,
-        invoiceItem: billingData.stop?.invoiceItem,
-      },
-    };
+    if (billingData) {
+      return {
+        withBillingActive: billingData.withBillingActive,
+        lastUpdate: Utils.convertToDate(billingData.lastUpdate),
+        stop: {
+          status: billingData.stop?.status,
+          invoiceID: DatabaseUtils.convertToObjectID(billingData.stop?.invoiceID),
+          invoiceNumber: billingData.stop?.invoiceNumber,
+          invoiceStatus: billingData.stop?.invoiceStatus,
+          invoiceItem: billingData.stop?.invoiceItem,
+        },
+      };
+    }
+    return null;
   }
 
   private static getTransactionsInErrorFacet(errorType: string) {

--- a/src/storage/mongodb/TransactionStorage.ts
+++ b/src/storage/mongodb/TransactionStorage.ts
@@ -173,17 +173,7 @@ export default class TransactionStorage {
       };
     }
     if (transactionToSave.billingData) {
-      transactionMDB.billingData = {
-        withBillingActive: transactionToSave.billingData.withBillingActive,
-        lastUpdate: Utils.convertToDate(transactionToSave.billingData.lastUpdate),
-        stop: {
-          status: transactionToSave.billingData.stop?.status,
-          invoiceID: DatabaseUtils.convertToObjectID(transactionToSave.billingData.stop?.invoiceID),
-          invoiceNumber: transactionToSave.billingData.stop?.invoiceNumber,
-          invoiceStatus: transactionToSave.billingData.stop?.invoiceStatus,
-          invoiceItem: transactionToSave.billingData.stop?.invoiceItem,
-        },
-      };
+      transactionMDB.billingData = TransactionStorage.normalizeBillingData(transactionToSave.billingData);
     }
     if (transactionToSave.ocpiData) {
       transactionMDB.ocpiData = {
@@ -278,12 +268,14 @@ export default class TransactionStorage {
       billingData: TransactionBillingData): Promise<void> {
     const startTime = Logging.traceDatabaseRequestStart();
     DatabaseUtils.checkTenantObject(tenant);
+    // Normalize billing data
+    const billingDataMDB = TransactionStorage.normalizeBillingData(billingData);
     // Modify document
     await global.database.getCollection<any>(tenant.id, 'transactions').findOneAndUpdate(
       { '_id': id },
       {
         $set: {
-          billingData
+          billingData: billingDataMDB
         }
       },
       { upsert: false });
@@ -1330,6 +1322,20 @@ export default class TransactionStorage {
     return {
       count: notifySessionNotStartedMDB.length,
       result: notifySessionNotStartedMDB
+    };
+  }
+
+  private static normalizeBillingData(billingData: TransactionBillingData): any {
+    return {
+      withBillingActive: billingData.withBillingActive,
+      lastUpdate: Utils.convertToDate(billingData.lastUpdate),
+      stop: {
+        status: billingData.stop?.status,
+        invoiceID: DatabaseUtils.convertToObjectID(billingData.stop?.invoiceID),
+        invoiceNumber: billingData.stop?.invoiceNumber,
+        invoiceStatus: billingData.stop?.invoiceStatus,
+        invoiceItem: billingData.stop?.invoiceItem,
+      },
     };
   }
 


### PR DESCRIPTION
Minor change to make sure the invoiceID is always persisted as an ObjectId().

Migration of old transactions should be necessary, but the information is not yet used by the UI and a SynchronizeInvoice endpoint is planned. This endpoint will somehow fix old transactions as well.