### PR TITLE
Fix - wrong amperage limit

### DIFF
--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -1820,9 +1820,8 @@ export default class OCPPUtils {
       // Return the minimal value
       return connectorAmperageLimitMin;
     }
-    // Return the max value
-    const connectorAmperageLimitMax = Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
-    return connectorAmperageLimitMax;
+    // Return the maximal value
+    return Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
   }
 
   private static async setConnectorPhaseAssignment(tenant: Tenant, chargingStation: ChargingStation, connector: Connector, nrOfPhases?: number): Promise<void> {

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -1814,15 +1814,15 @@ export default class OCPPUtils {
 
   private static checkAndGetConnectorAmperageLimit(chargingStation: ChargingStation, connector: Connector, nrOfPhases?: number): number {
     const numberOfPhases = nrOfPhases ?? Utils.getNumberOfConnectedPhases(chargingStation, null, connector.connectorId);
-    const connectorAmperageLimitMax = Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
     const connectorAmperageLimitMin = StaticLimitAmps.MIN_LIMIT_PER_PHASE * numberOfPhases;
-    if (!Utils.objectHasProperty(connector, 'amperageLimit') || (Utils.objectHasProperty(connector, 'amperageLimit') && Utils.isNullOrUndefined(connector.amperageLimit))) {
-      return connectorAmperageLimitMax;
-    } else if (Utils.objectHasProperty(connector, 'amperageLimit') && connector.amperageLimit > connectorAmperageLimitMax) {
-      return connectorAmperageLimitMax;
-    } else if (Utils.objectHasProperty(connector, 'amperageLimit') && connector.amperageLimit < connectorAmperageLimitMin) {
+    if (connector.amperageLimit // Must be ignored when set to 0
+      && connector.amperageLimit < connectorAmperageLimitMin) {
+      // Return the minimal value
       return connectorAmperageLimitMin;
     }
+    // Return the max value
+    const connectorAmperageLimitMax = Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
+    return connectorAmperageLimitMax;
   }
 
   private static async setConnectorPhaseAssignment(tenant: Tenant, chargingStation: ChargingStation, connector: Connector, nrOfPhases?: number): Promise<void> {


### PR DESCRIPTION

The problem occurs because of a wrong amperage limit on connector level in the database:

```
connectors: [{id: null, connectorId: 1, currentInstantWatts: 0, currentStateOfCharge: 0,…},…]
0: {id: null, connectorId: 1, currentInstantWatts: 0, currentStateOfCharge: 0,…}
amperage: 96
amperageLimit: 18
chargePointID: 1
connectorId: 1
currentInactivityStatus: "I"
currentInstantWatts: 0
currentStateOfCharge: 0
currentTagID: null
currentTotalConsumptionWh: 0
currentTotalInactivitySecs: 0
currentTransactionDate: null
currentTransactionID: 0
currentType: null
currentUserID: null
errorCode: "NoError"
id: null
info: null
numberOfConnectedPhase: null
phaseAssignmentToGrid: {csPhaseL1: "L1", csPhaseL2: "L2", csPhaseL3: "L3"}
power: 22080
status: "Available"
statusLastChangedOn: "2022-04-11T12:10:44.000Z"
tariffID: null
type: "T2"
vendorErrorCode: null
voltage: 0
```
The amperage limit is taken by two, because there are two connectors to limit. -> 36 Amps.

This seems to be a bug from the template enriching code, but it is really hard to reproduce. My guess is that it has to do with the backup connector implementation.
The connectors are saved with the following line in ChargingStationStorage:

`amperageLimit: Utils.convertToInt(connector.amperageLimit),`

This will save the amperage limit to 0 if the value is not set.

Then when the charging station is enriched again. The backup connector which is taken as a base has connectorLimit: 0 in the db. Which is checked by a method in OCPPUtils (checkAndGetConnectorAmperageLimit), which assumes 0 is not possible as amperage limit and sets the minimum.


