### PR TITLE
Throw Http Bad Request (400) for HTTP param validations instead of Internal Server Error (500)

### DIFF
--- a/src/validator/SchemaValidator.ts
+++ b/src/validator/SchemaValidator.ts
@@ -3,9 +3,9 @@ import { AnySchemaObject, DataValidateFunction, DataValidationCxt } from 'ajv/di
 
 import AppError from '../exception/AppError';
 import Constants from '../utils/Constants';
-import { HTTPError } from '../types/HTTPError';
 import { ObjectId } from 'mongodb';
 import Schema from '../types/validator/Schema';
+import { StatusCodes } from 'http-status-codes';
 import _ from 'lodash';
 import addFormats from 'ajv-formats';
 import chalk from 'chalk';
@@ -129,7 +129,7 @@ export default class SchemaValidator {
         }
       }
       throw new AppError({
-        errorCode: HTTPError.GENERAL_ERROR,
+        errorCode: StatusCodes.BAD_REQUEST,
         message: concatenatedErrors.join(', '),
         module: this.moduleName,
         method: 'validate',

--- a/test/api/AuthenticationTest.ts
+++ b/test/api/AuthenticationTest.ts
@@ -233,7 +233,7 @@ describe('Authentication Service (utall)', () => {
       const newUser = UserFactory.buildRegisterUser();
       delete newUser.password;
       const response = await CentralServerService.defaultInstance.authenticationApi.registerUser(newUser, testData.adminTenant);
-      expect(response.status).to.be.eql(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.be.eql(StatusCodes.BAD_REQUEST);
       expect(response.data).to.not.have.property('token');
     });
 
@@ -242,7 +242,7 @@ describe('Authentication Service (utall)', () => {
       const newUser = UserFactory.buildRegisterUser();
       newUser.password = '';
       const response = await CentralServerService.defaultInstance.authenticationApi.registerUser(newUser, testData.adminTenant);
-      expect(response.status).to.be.eql(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.be.eql(StatusCodes.BAD_REQUEST);
       expect(response.data).to.not.have.property('token');
     });
 
@@ -251,7 +251,7 @@ describe('Authentication Service (utall)', () => {
       const newUser = UserFactory.buildRegisterUser();
       newUser.password = '1234';
       const response = await CentralServerService.defaultInstance.authenticationApi.registerUser(newUser, testData.adminTenant);
-      expect(response.status).to.be.eql(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.be.eql(StatusCodes.BAD_REQUEST);
       expect(response.data).to.not.have.property('token');
     });
 
@@ -269,7 +269,7 @@ describe('Authentication Service (utall)', () => {
       // Call
       const response = await CentralServerService.defaultInstance.authenticationApi.login(
         testData.adminEmail, null, true, testData.adminTenant);
-      expect(response.status).to.be.eql(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.be.eql(StatusCodes.BAD_REQUEST);
       expect(response.data).to.not.have.property('token');
     });
 
@@ -277,7 +277,7 @@ describe('Authentication Service (utall)', () => {
       // Call
       const response = await CentralServerService.defaultInstance.authenticationApi.login(
         testData.adminEmail, testData.adminPassword, false, testData.adminTenant);
-      expect(response.status).to.be.eql(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.be.eql(StatusCodes.BAD_REQUEST);
       expect(response.data).to.not.have.property('token');
     });
 
@@ -285,7 +285,7 @@ describe('Authentication Service (utall)', () => {
       // Call
       const response = await CentralServerService.defaultInstance.authenticationApi.login(
         testData.adminEmail, testData.adminPassword, null, testData.adminTenant);
-      expect(response.status).to.be.eql(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.be.eql(StatusCodes.BAD_REQUEST);
       expect(response.data).to.not.have.property('token');
     });
 
@@ -293,7 +293,7 @@ describe('Authentication Service (utall)', () => {
       // Call
       const response = await CentralServerService.defaultInstance.authenticationApi.login(
         null, testData.adminPassword, true, testData.adminTenant);
-      expect(response.status).to.be.eql(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.be.eql(StatusCodes.BAD_REQUEST);
       expect(response.data).to.not.have.property('token');
     });
 

--- a/test/api/CarTest.ts
+++ b/test/api/CarTest.ts
@@ -113,7 +113,7 @@ describe('Car', () => {
         'Should not be able to get a detailed car catalog without ID',
         async () => {
           const response = await testData.centralService.carApi.readCarCatalog(null);
-          expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+          expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
         }
       );
 
@@ -138,7 +138,7 @@ describe('Car', () => {
             vin: null,
           }), false
         );
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       });
 
       it(
@@ -151,7 +151,7 @@ describe('Car', () => {
               licensePlate: null,
             }), false
           );
-          expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+          expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
         }
       );
 
@@ -163,7 +163,7 @@ describe('Car', () => {
             type: null,
           }), false
         );
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       });
 
       it(
@@ -358,7 +358,7 @@ describe('Car', () => {
       'Should not be able to get a detailed car catalog without ID',
       async () => {
         const response = await testData.centralService.carApiSuperTenant.readCarCatalog(null);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 

--- a/test/api/OCPPCommonTests.ts
+++ b/test/api/OCPPCommonTests.ts
@@ -428,7 +428,7 @@ export default class OCPPCommonTests {
         'connectorId': this.chargingStationContext.getChargingStation().connectors[0].connectorId
       }
     });
-    expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
   }
 
   public async testRemoteStartTransactionWithExternalUser(): Promise<void> {

--- a/test/api/SiteAreaOrgTest.ts
+++ b/test/api/SiteAreaOrgTest.ts
@@ -268,7 +268,7 @@ describe('Site Area', () => {
         async () => {
           // Try to call Consumptions without Site Area ID
           const response = await testData.centralUserService.siteAreaApi.readConsumption(null,null,null);
-          expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+          expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
         }
       );
 
@@ -277,7 +277,7 @@ describe('Site Area', () => {
         async () => {
           // Try to call Consumptions without start and end date
           const response = await testData.centralUserService.siteAreaApi.readConsumption(testData.siteAreaContext.getSiteArea().id, null, null);
-          expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+          expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
         }
       );
 
@@ -525,7 +525,7 @@ describe('Site Area', () => {
         async () => {
           // Try to call Consumptions without Site Area ID
           const response = await testData.centralUserService.siteAreaApi.readConsumption(null,null,null);
-          expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+          expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
         }
       );
 
@@ -534,7 +534,7 @@ describe('Site Area', () => {
         async () => {
           // Try to call Consumptions without start and end date
           const response = await testData.centralUserService.siteAreaApi.readConsumption(testData.siteAreaContext.getSiteArea().id, null, null);
-          expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+          expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
         }
       );
 

--- a/test/api/TenantTest.ts
+++ b/test/api/TenantTest.ts
@@ -152,7 +152,7 @@ describe('Tenant', () => {
       // Exec
       const response = await CentralServerService.defaultInstance.getEntityById(
         CentralServerService.defaultInstance.tenantApi, { id: 'youAreInvalid' }, false);
-      expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
     });
 
     it('Should not be possible to read an unknown tenant', async () => {
@@ -169,7 +169,7 @@ describe('Tenant', () => {
       // Call
       const response = await CentralServerService.defaultInstance.createEntity(
         CentralServerService.defaultInstance.tenantApi, tenant, false);
-      expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
     });
 
     it('Should not be possible to create a tenant without a name', async () => {
@@ -179,7 +179,7 @@ describe('Tenant', () => {
       // Call
       const response = await CentralServerService.defaultInstance.createEntity(
         CentralServerService.defaultInstance.tenantApi, tenant, false);
-      expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
     });
 
     it(
@@ -191,7 +191,7 @@ describe('Tenant', () => {
         // Call
         const response = await CentralServerService.defaultInstance.createEntity(
           CentralServerService.defaultInstance.tenantApi, tenant, false);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 
@@ -204,7 +204,7 @@ describe('Tenant', () => {
         // Call
         const response = await CentralServerService.defaultInstance.createEntity(
           CentralServerService.defaultInstance.tenantApi, tenant, false);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 
@@ -217,7 +217,7 @@ describe('Tenant', () => {
         // Call
         const response = await CentralServerService.defaultInstance.createEntity(
           CentralServerService.defaultInstance.tenantApi, tenant, false);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 
@@ -230,7 +230,7 @@ describe('Tenant', () => {
         // Call
         const response = await CentralServerService.defaultInstance.createEntity(
           CentralServerService.defaultInstance.tenantApi, tenant, false);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 
@@ -243,7 +243,7 @@ describe('Tenant', () => {
         // Call
         const response = await CentralServerService.defaultInstance.createEntity(
           CentralServerService.defaultInstance.tenantApi, tenant, false);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 
@@ -256,7 +256,7 @@ describe('Tenant', () => {
         // Call
         const response = await CentralServerService.defaultInstance.createEntity(
           CentralServerService.defaultInstance.tenantApi, tenant, false);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 
@@ -269,7 +269,7 @@ describe('Tenant', () => {
         // Call
         const response = await CentralServerService.defaultInstance.createEntity(
           CentralServerService.defaultInstance.tenantApi, tenant, false);
-        expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
       }
     );
 

--- a/test/api/TransactionCommonTests.ts
+++ b/test/api/TransactionCommonTests.ts
@@ -72,12 +72,12 @@ export default class TransactionCommonTests {
 
   public async testReadTransactionWithInvalidId() {
     const response = await this.transactionUserService.transactionApi.readById('&é"\'(§è!çà)');
-    expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
   }
 
   public async testReadTransactionWithoutId() {
     const response = await this.transactionUserService.transactionApi.readById(null);
-    expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
   }
 
   public async testReadTransactionOfUser(allowed = true, transactionTag: string) {
@@ -1022,12 +1022,12 @@ export default class TransactionCommonTests {
 
   public async testDeleteTransactionWithInvalidId() {
     const response = await this.transactionUserService.transactionApi.delete('&é"\'(§è!çà)');
-    expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
   }
 
   public async testDeleteTransactionWithoutId() {
     const response = await this.transactionUserService.transactionApi.delete(null);
-    expect(response.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.status).to.equal(StatusCodes.BAD_REQUEST);
   }
 
   public async testDeleteStartedTransaction(allowed = true) {


### PR DESCRIPTION
Throw Http Bad Request (400) for HTTP param validations instead of Internal Server Error (500)
Aligned Unit Tests