### PR TITLE
Add ocpi data flags for export/push cdr

### DIFF
--- a/src/authorization/AuthorizationsDefinition.ts
+++ b/src/authorization/AuthorizationsDefinition.ts
@@ -695,7 +695,7 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
           }
         },
         attributes: [
-          'id', 'ocpiData'
+          'id', 'ocpiData', 'ocpi', 'ocpiWithCdr'
         ]
       },
       {
@@ -2733,7 +2733,7 @@ export const AUTHORIZATION_DEFINITION: AuthorizationDefinition = {
           }
         },
         attributes: [
-          'id', 'ocpiData'
+          'id', 'ocpiData', 'ocpi', 'ocpiWithCdr'
         ]
       },
       {

--- a/src/server/rest/v1/service/TransactionService.ts
+++ b/src/server/rest/v1/service/TransactionService.ts
@@ -551,7 +551,7 @@ export default class TransactionService {
     // Filter
     const filteredRequest = TransactionValidatorRest.getInstance().validateTransactionCdrExportReq(req.query);
     // Get Transaction
-    const transaction = await UtilsService.checkAndGetTransactionAuthorization(req.tenant, req.user, filteredRequest.ID, Action.EXPORT_OCPI_CDR, action);
+    const transaction = await UtilsService.checkAndGetTransactionAuthorization(req.tenant, req.user, filteredRequest.ID, Action.EXPORT_OCPI_CDR, action, null, null, true);
     if (!transaction?.ocpiData) {
       throw new AppError({
         ...LoggingHelper.getTransactionProperties(transaction),
@@ -741,7 +741,7 @@ export default class TransactionService {
   }
 
   private static async getTransactions(req: Request, filteredRequest: HttpTransactionsGetRequest,
-    authAction: Action = Action.LIST, additionalFilters: Record<string, any> = {}): Promise<DataResult<Transaction>> {
+      authAction: Action = Action.LIST, additionalFilters: Record<string, any> = {}): Promise<DataResult<Transaction>> {
     // Get authorization filters
     const authorizations = await AuthorizationService.checkAndGetTransactionsAuthorizations(
       req.tenant, req.user, authAction, filteredRequest, false);
@@ -803,7 +803,7 @@ export default class TransactionService {
   }
 
   private static async transactionSoftStop(action: ServerAction, transaction: Transaction, chargingStation: ChargingStation,
-    connector: Connector, req: Request, res: Response, next: NextFunction): Promise<void> {
+      connector: Connector, req: Request, res: Response, next: NextFunction): Promise<void> {
     // Check if already stopped
     if (transaction.stop) {
       // Clear Connector
@@ -856,7 +856,7 @@ export default class TransactionService {
   }
 
   private static async checkAndGetTransactionChargingStationConnector(action: ServerAction, tenant: Tenant, user: UserToken,
-    transactionID: number, authAction: Action): Promise<{ transaction: Transaction; chargingStation: ChargingStation; connector: Connector; }> {
+      transactionID: number, authAction: Action): Promise<{ transaction: Transaction; chargingStation: ChargingStation; connector: Connector; }> {
     // Check dynamic auth
     const transaction = await UtilsService.checkAndGetTransactionAuthorization(tenant, user, transactionID, authAction, action);
     const { chargingStation, connector } = await TransactionService.checkAndGetChargingStationConnector(action, tenant, user,
@@ -865,7 +865,7 @@ export default class TransactionService {
   }
 
   private static async checkAndGetChargingStationConnector(action: ServerAction, tenant: Tenant, user: UserToken,
-    chargingStationID: string, connectorID: number, authAction: Action): Promise<{ chargingStation: ChargingStation; connector: Connector; }> {
+      chargingStationID: string, connectorID: number, authAction: Action): Promise<{ chargingStation: ChargingStation; connector: Connector; }> {
     // Get the Charging Station
     const chargingStation = await UtilsService.checkAndGetChargingStationAuthorization(tenant, user, chargingStationID, authAction, action, null, { withSiteArea: true });
     // Check connector

--- a/src/storage/mongodb/TransactionStorage.ts
+++ b/src/storage/mongodb/TransactionStorage.ts
@@ -670,14 +670,14 @@ export default class TransactionStorage {
       $limit: dbParams.limit
     });
     // Add OCPI data
-    if (projectFields && projectFields.includes('ocpi')) {
+    if (!projectFields || projectFields && projectFields.includes('ocpi')) {
       aggregation.push({
         $addFields: {
           'ocpi': { $gt: ['$ocpiData', null] }
         }
       });
     }
-    if (projectFields && projectFields.includes('ocpiWithCdr')) {
+    if (!projectFields || projectFields && projectFields.includes('ocpiWithCdr')) {
       aggregation.push({
         $addFields: {
           'ocpiWithCdr': {
@@ -1565,7 +1565,7 @@ export default class TransactionStorage {
           $addFields: { status: '$connector.status' }
         });
       }
-      if ( params.transactionsToStop ) {
+      if (params.transactionsToStop) {
         aggregation.push(
           {
             // Make sure we have connectors (to avoid conflicts with a OcppBootNotification where connectors temporarily are cleared)


### PR DESCRIPTION
This fixes the export / push CDR authorizations:
- Use projected field for export CDR: in order to have the ocpi & ocpiWithCdr flags that are required to authorize the action.
- When no projected fields are set, by default we add the flags as it is required for the push CDR

@ClaudeROSSI I will create an issue to optimize the pushCDR endpoint, so that it will also use projected fields