### PR TITLE
Wall Box Chargers - Custom Vendor Integration

### DIFF
--- a/src/integration/charging-station-vendor/ChargingStationVendorFactory.ts
+++ b/src/integration/charging-station-vendor/ChargingStationVendorFactory.ts
@@ -4,6 +4,7 @@ import ChargingStationVendorIntegration from './ChargingStationVendorIntegration
 import DefaultChargingStationVendorIntegration from './default/DefaultChargingStationVendorIntegration';
 import EVBOXChargingStationVendorIntegration from './evbox/EVBOXChargingStationVendorIntegration';
 import KebaChargingStationVendorIntegration from './keba/KebaChargingStationVendorIntegration';
+import WALLBOXChargingStationVendorIntegration from './wallbox/WALLBOXChargingStationVendorIntegration';
 
 export default class ChargingStationVendorFactory {
   public static getChargingStationVendorImpl(chargingStation: ChargingStation): ChargingStationVendorIntegration {
@@ -14,6 +15,9 @@ export default class ChargingStationVendorFactory {
         break;
       case ChargerVendor.KEBA:
         chargingStationVendorImpl = new KebaChargingStationVendorIntegration(chargingStation);
+        break;
+      case ChargerVendor.WALLBOX:
+        chargingStationVendorImpl = new WALLBOXChargingStationVendorIntegration(chargingStation);
         break;
       default:
         chargingStationVendorImpl = new DefaultChargingStationVendorIntegration(chargingStation);

--- a/src/integration/charging-station-vendor/wallbox/WALLBOXChargingStationVendorIntegration.ts
+++ b/src/integration/charging-station-vendor/wallbox/WALLBOXChargingStationVendorIntegration.ts
@@ -1,0 +1,19 @@
+import ChargingStation, { ChargePoint } from '../../../types/ChargingStation';
+
+import { ChargingProfile } from '../../../types/ChargingProfile';
+import ChargingStationVendorIntegration from '../ChargingStationVendorIntegration';
+import { OCPPSetChargingProfileResponse } from '../../../types/ocpp/OCPPClient';
+import Tenant from '../../../types/Tenant';
+
+export default class WALLBOXChargingStationVendorIntegration extends ChargingStationVendorIntegration {
+  constructor(chargingStation: ChargingStation) {
+    super(chargingStation);
+  }
+
+  // Wallbox only supports stack level 0
+  public async setChargingProfile(tenant: Tenant, chargingStation: ChargingStation, chargePoint: ChargePoint,
+      chargingProfile: ChargingProfile): Promise<OCPPSetChargingProfileResponse | OCPPSetChargingProfileResponse[]> {
+    chargingProfile.profile.stackLevel = 0;
+    return super.setChargingProfile(tenant, chargingStation, chargePoint, chargingProfile);
+  }
+}

--- a/src/types/ChargingStation.ts
+++ b/src/types/ChargingStation.ts
@@ -320,4 +320,5 @@ export enum ChargerVendor {
   ABB = 'abb',
   EVBOX = 'ev-box',
   KEBA = 'keba ag',
+  WALLBOX = 'wall box chargers',
 }


### PR DESCRIPTION
This is a quick fix for Wall Box Chargers not accepting charging profiles on stack levels other than 0. 
On a long term we should refactor the charging profile logic to use stack level 0 whenever possible.